### PR TITLE
Initialize rgroup to a harmless value at the beginning of do_get_keycode_new.

### DIFF
--- a/src/xpra/x11/server_keyboard_config.py
+++ b/src/xpra/x11/server_keyboard_config.py
@@ -525,6 +525,7 @@ class KeyboardConfig(KeyboardConfigBase):
             l(msg, *args)
         def klog(msg, *args):
             kmlog("do_get_keycode%s"+msg, (client_keycode, keyname, pressed, modifiers, group), *args)
+        rgroup = group
         #non-native: try harder to find matching keysym
         #first, try to honour shift state:
         lock = ("lock" in modifiers) and (SHIFT_LOCK or (bool(keystr) and keystr.isalpha()))


### PR DESCRIPTION
Per IRC, this was due to a backport.

There are code paths through the `do_get_keycode_new` function where `rgroup` is never set. This was leading to the following error when I typed various keys, include backspace, pgup, and pgdown!

```
Traceback (most recent call last):
  File "/home/william/Projects/remote/xpra/install/lib/python3.8/site-packages/xpra/server/mixins/input_server.py", line 163, in _process_key_action
    keycode, group = self.get_keycode(ss, client_keycode, keyname, pressed, modifiers, keystr, group)
  File "/home/william/Projects/remote/xpra/install/lib/python3.8/site-packages/xpra/server/mixins/input_server.py", line 184, in get_keycode
    return ss.get_keycode(client_keycode, keyname, pressed, modifiers, keystr, group)
  File "/home/william/Projects/remote/xpra/install/lib/python3.8/site-packages/xpra/server/source/input_mixin.py", line 124, in get_keycode
    return kc.get_keycode(client_keycode, keyname, pressed, modifiers, keystr, group)
  File "/home/william/Projects/remote/xpra/install/lib/python3.8/site-packages/xpra/server/keyboard_config_base.py", line 54, in get_keycode
    keycode, group = self.do_get_keycode(client_keycode, keyname, pressed, modifiers, keystr, group)
  File "/home/william/Projects/remote/xpra/install/lib/python3.8/site-packages/xpra/x11/server_keyboard_config.py", line 463, in do_get_keycode
    return self.do_get_keycode_new(client_keycode, keyname, pressed, modifiers, group)
  File "/home/william/Projects/remote/xpra/install/lib/python3.8/site-packages/xpra/x11/server_keyboard_config.py", line 613, in do_get_keycode_new
    return keycode, rgroup
UnboundLocalError: local variable 'rgroup' referenced before assignment
```

This PR initializes `rgroup` to 0, so if nothing modifies the value, callers of `do_get_keycode_new` treat the return value as a no-op.