### PR TITLE
add xdamage to xpra.x11.gtk3.gdk_bindings

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1899,7 +1899,7 @@ if gtk_x11_ENABLED:
                 ))
     cython_add(Extension("xpra.x11.gtk3.gdk_bindings",
                 ["xpra/x11/gtk3/gdk_bindings.pyx", "xpra/x11/gtk3/gdk_x11_macros.c"],
-                **pkgconfig("gdk-3.0")
+                **pkgconfig("gdk-3.0", "xdamage")
                 ))
 
 if client_ENABLED and gtk3_ENABLED:


### PR DESCRIPTION
Xpra fails to start with the following error.

```console
xpra start :19 --daemon=off
2021-05-07 22:37:47,369 Warning: failed to create socket directory '/run/xpra'
2021-05-07 22:37:47,369  [Errno 13] Permission denied: '/run/xpra'
2021-05-07 22:37:47,370 Warning: some of the sockets are in an unknown state:
2021-05-07 22:37:47,370  /run/user/1000/xpra/etude-19
2021-05-07 22:37:47,370  /home/matt/.xpra/etude-19
2021-05-07 22:37:47,370  please wait as we allow the socket probing to timeout
2021-05-07 22:37:53,377 created unix domain socket '/run/user/1000/xpra/etude-19'
2021-05-07 22:37:53,377 cannot create group socket '/run/xpra/etude-19'
2021-05-07 22:37:53,377  [Errno 2] No such file or directory
2021-05-07 22:37:53,377  /run/xpra does not exist
2021-05-07 22:37:53,377 created unix domain socket '/home/matt/.xpra/etude-19'
xpra main error:
Traceback (most recent call last):
  File "/nix/store/szrcby067ymn81fzhripvvcri09i6rx4-xpra-4.1.3/lib/python3.8/site-packages/xpra/scripts/main.py", line 126, in main
    return run_mode(script_file, err, options, args, mode, defaults)
  File "/nix/store/szrcby067ymn81fzhripvvcri09i6rx4-xpra-4.1.3/lib/python3.8/site-packages/xpra/scripts/main.py", line 401, in run_mode
    return do_run_mode(script_file, error_cb, options, args, mode, defaults)
  File "/nix/store/szrcby067ymn81fzhripvvcri09i6rx4-xpra-4.1.3/lib/python3.8/site-packages/xpra/scripts/main.py", line 432, in do_run_mode
    return run_server(script_file, error_cb, options, args, mode, defaults)
  File "/nix/store/szrcby067ymn81fzhripvvcri09i6rx4-xpra-4.1.3/lib/python3.8/site-packages/xpra/scripts/main.py", line 2158, in run_server
    return do_run_server(error_cb, options, mode, script_file, args, desktop_display, progress_cb)
  File "/nix/store/szrcby067ymn81fzhripvvcri09i6rx4-xpra-4.1.3/lib/python3.8/site-packages/xpra/scripts/server.py", line 892, in do_run_server
    app = make_server(clobber)
  File "/nix/store/szrcby067ymn81fzhripvvcri09i6rx4-xpra-4.1.3/lib/python3.8/site-packages/xpra/scripts/server.py", line 329, in make_server
    from xpra.x11.server import XpraServer
  File "/nix/store/szrcby067ymn81fzhripvvcri09i6rx4-xpra-4.1.3/lib/python3.8/site-packages/xpra/x11/server.py", line 24, in <module>
    from xpra.x11.gtk_x11.prop import prop_set
  File "/nix/store/szrcby067ymn81fzhripvvcri09i6rx4-xpra-4.1.3/lib/python3.8/site-packages/xpra/x11/gtk_x11/prop.py", line 21, in <module>
    from xpra.x11.gtk_x11.gdk_bindings import (
  File "/nix/store/szrcby067ymn81fzhripvvcri09i6rx4-xpra-4.1.3/lib/python3.8/site-packages/xpra/x11/gtk_x11/gdk_bindings.py", line 11, in <module>
    from xpra.x11.gtk3 import gdk_bindings  #@UnresolvedImport, @UnusedImport
ImportError: /nix/store/szrcby067ymn81fzhripvvcri09i6rx4-xpra-4.1.3/lib/python3.8/site-packages/xpra/x11/gtk3/gdk_bindings.cpython-38-x86_64-linux-gnu.so: undefined symbol: XDamageQueryExtension
```

This patch allows it to run succesfully. It looks like these bindings depend directly on xdamage, but on other distros, this must get picked up from a global location or transitively somehow.