### PR TITLE
Wrap Xvfb command string only when generating .conf file

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -863,7 +863,7 @@ def build_xpra_conf(install_dir):
     #no python-avahi on RH / CentOS, need dbus module on *nix:
     mdns = mdns_ENABLED and (OSX or WIN32 or (not is_RH() and dbus_ENABLED))
     SUBS = {
-            'xvfb_command'          : xvfb_cmd_str(xvfb_command),
+            'xvfb_command'          : xvfb_cmd_str(xvfb_command, wrap=True),
             'fake_xinerama'         : fake_xinerama,
             'ssh_command'           : "auto",
             'key_shortcuts'         : "".join(("key-shortcut = %s\n" % x) for x in get_default_key_shortcuts()),

--- a/xpra/scripts/config.py
+++ b/xpra/scripts/config.py
@@ -184,7 +184,7 @@ def detect_xvfb_command(conf_dir="/etc/xpra/", bin_dir=None,
     return Xorg_suid_check()
 
 
-def xvfb_cmd_str(xvfb):
+def xvfb_cmd_str(xvfb, wrap=False):
     xvfb_str = ""
     while xvfb:
         s = ""
@@ -201,7 +201,10 @@ def xvfb_cmd_str(xvfb):
             else:
                 s += " "+v
         if xvfb_str:
-            xvfb_str += " \\\n    "
+            if wrap:
+                xvfb_str += " \\\n    "
+            else:
+                xvfb_str += " "
         xvfb_str += s
     return xvfb_str
 


### PR DESCRIPTION
When xvfb command cannot be obtained from a config file, `xpra.scripts.config.xvfb_cmd_str()` is called to generate it, but it contains escaped newlines (to format it nicely when generating `/etc/xpra/conf.d/55_server_x11.conf` at compile time). This makes it only wrap lines at compile time in setup.py.