### PR TITLE
fix html5 client

### DIFF
--- a/xpra/platform/xposix/paths.py
+++ b/xpra/platform/xposix/paths.py
@@ -115,12 +115,15 @@ def do_get_user_conf_dirs(uid):
 
 def get_runtime_dir():
     runtime_dir = os.environ.get("XDG_RUNTIME_DIR")
-    if runtime_dir or sys.platform.startswith("linux"):
-        return "$XDG_RUNTIME_DIR"
-    for d in ("/run/user", "/var/run/user"):
-        if os.path.exists(d) and os.path.isdir(d):
-            runtime_dir = d+"/$UID"
-            break
+    if runtime_dir:
+        return runtime_dir
+    if sys.platform.startswith("linux"):
+        for d in ("/run/user", "/var/run/user"):
+            if os.path.exists(d) and os.path.isdir(d):
+                runtime_dir = d+"/$UID"
+                break
+        if not runtime_dir:
+           return "$XDG_RUNTIME_DIR"
     return runtime_dir
 
 def _get_xpra_runtime_dir():


### PR DESCRIPTION
This PR addresses multiple issues that made HTML5 client unusable on Debian:

﻿- Replace 'sns.get' with 'bytestostr' iterator
- Treat existing but empty 'start_new_session' dict
- Test for absolute socket filename path
- Add expandable '/run/user/$UID/xpra' to 'socket_dirs'

The PR was tested with all modes (connect, start, start-desktop, shadow)
and everything is working as expected.
