### PR TITLE
Do not include malloc.h on OpenBSD

### DIFF
--- a/xpra/buffers/memalign.c
+++ b/xpra/buffers/memalign.c
@@ -13,7 +13,7 @@
 #ifdef _WIN32
 #define _STDINT_H
 #endif
-#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__DragonFly__)
+#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__DragonFly__) && !defined(__OpenBSD__)
 #include <malloc.h>
 #endif
 

--- a/xpra/buffers/memalign.c
+++ b/xpra/buffers/memalign.c
@@ -13,7 +13,8 @@
 #ifdef _WIN32
 #define _STDINT_H
 #endif
-#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__DragonFly__) && !defined(__OpenBSD__)
+#if !defined(__APPLE__) && !defined(__FreeBSD__) && !defined(__DragonFly__) \
+		&& !defined(__OpenBSD__)
 #include <malloc.h>
 #endif
 


### PR DESCRIPTION
Just adding OpenBSD to the chain. :)

Cheers.
Elias.