### PR TITLE
Do not close socket on BlockingIOError

### DIFF
--- a/xpra/net/bytestreams.py
+++ b/xpra/net/bytestreams.py
@@ -55,6 +55,8 @@ CLOSED_EXCEPTIONS = ()
 def can_retry(e):
     if isinstance(e, socket.timeout):
         return "socket.timeout"
+    if isinstance(e, BlockingIOError):
+        return True
     if isinstance(e, BrokenPipeError):
         raise ConnectionClosedException(e) from None
     if isinstance(e, OSError):


### PR DESCRIPTION
Fixes random and hard-to-localize disconnects on heavy load, like
playing a YouTube fullscreen video using Xpra proxy server and HTML5
client.
