### PR TITLE
Redirect plain HTTP requests to HTTPS on 'ssl=on'

### DIFF
--- a/xpra/server/proxy/proxy_instance_process.py
+++ b/xpra/server/proxy/proxy_instance_process.py
@@ -97,7 +97,7 @@ class ProxyInstanceProcess(ProxyInstance, QueueScheduler, Process):
 
 
     def server_message_queue(self):
-        while not self.exit:
+        while not self.exit and self.message_queue:
             log("waiting for server message on %s", self.message_queue)
             m = self.message_queue.get()
             log("received proxy server message: %s", m)

--- a/xpra/server/proxy/proxy_instance_process.py
+++ b/xpra/server/proxy/proxy_instance_process.py
@@ -30,7 +30,7 @@ from xpra.queue_scheduler import QueueScheduler
 from xpra.version_util import XPRA_VERSION
 from xpra.make_thread import start_thread
 from xpra.version_util import full_version_str
-from xpra.net.socket_util import create_unix_domain_socket
+from xpra.net.socket_util import create_unix_domain_socket, handle_socket_error
 from xpra.platform.dotxpra import DotXpra
 from xpra.net.bytestreams import SocketConnection, SOCKET_TIMEOUT
 from xpra.log import Logger
@@ -220,7 +220,7 @@ class ProxyInstanceProcess(ProxyInstance, QueueScheduler, Process):
         except Exception as e:
             log("create_unix_domain_socket failed for '%s'", sockpath, exc_info=True)
             log.error("Error: failed to setup control socket '%s':", sockpath)
-            log.error(" %s", e)
+            handle_socket_error(sockpath, 0o600, e)
             stop(e)
             return False
         self.control_socket = sock


### PR DESCRIPTION
This PR fixes two issues:

﻿- Use threaded proxy server mode for insecure websockets
- Redirect insecure HTTP GET/HEAD requests to HTTPS

We can of course introduce new possible value to 'ssl' (like
'force', 'required', 'ssl-only') but my bet is that if user
turns on SSL, insecure HTTP requests must be redirected to
HTTPS.
