### PR TITLE
Add python3-distutils as runtime-dep on Debian

### DIFF
--- a/packaging/debian/xpra/control
+++ b/packaging/debian/xpra/control
@@ -40,6 +40,8 @@ Depends: ${misc:Depends}, ${python3:Depends}, ${shlibs:Depends}
         ,python3-gi
         ,gir1.2-gtk-3.0
         ,python3-cairo
+# for spawn
+        ,python3-distutils
         ,python3-gi-cairo
 # for opengl support:
         ,python3-opengl


### PR DESCRIPTION
'os_util.which()' is called in 'ibus-daemon' search routine
and 'xpra start' fails to start in a pristine Debian bullseye
container due to missing runtime dependency on python3-distutils
