### PR TITLE
`/etc/profile` is listed as `source=` and `source-start=`

### DIFF
--- a/fs/etc/xpra/conf.d/60_server.conf.in
+++ b/fs/etc/xpra/conf.d/60_server.conf.in
@@ -18,8 +18,7 @@ start-via-proxy = no
 #source = /etc/xpra/server.env
 source = /etc/profile
 
-# Scripts that can modify the environment of the commands started by the server:
-#source-start = /etc/profile
+# Scripts that can modify the environment of the commands started by the server
 # This one is useful for avoiding delays when running gnome applications:
 #source-start = gnome-keyring-daemon -s
 


### PR DESCRIPTION
`/etc/profile` cannot be _started_ - it can only be sourced.
And since ddd9195a67784cafd2a7ca6eb00605ad770119e8 it is being sourced already.