### PR TITLE
use POSIX compliant `command -v` instead of `which`

### DIFF
--- a/fs/bin/xpra_Xdummy
+++ b/fs/bin/xpra_Xdummy
@@ -61,7 +61,7 @@ elif [ -x "/usr/lib/xorg/Xorg" ]; then
 	#Ubuntu 16.10:
 	exec "/usr/lib/xorg/Xorg" "$@"
 else
-	XORG_BIN=$(which Xorg)
+	XORG_BIN=$(command -v Xorg)
 fi
 
 if [ ! -x "$XORG_BIN" ]; then

--- a/packaging/debian/xpra/xpra.postrm
+++ b/packaging/debian/xpra/xpra.postrm
@@ -4,7 +4,7 @@ set -e
 
 case "${1}" in
     purge|remove)
-        if [ -x "$(which delgroup)" ]; then
+        if [ -x "$(command -v delgroup)" ]; then
             delgroup --quiet --system --only-if-empty xpra || true
         fi
     ;;

--- a/setup.py
+++ b/setup.py
@@ -2045,7 +2045,7 @@ if (nvenc_ENABLED and cuda_kernels_ENABLED) or nvjpeg_ENABLED:
     options = [os.path.join(x, nvcc_exe) for x in path_options]
     def which(cmd):
         try:
-            code, out, _ = get_status_output(["which", cmd])
+            code, out, _ = get_status_output(["command -v", cmd])
             if code==0:
                 return out
         except:

--- a/tests/unittests/unit/process_test_util.py
+++ b/tests/unittests/unit/process_test_util.py
@@ -179,7 +179,7 @@ class ProcessTestUtil(unittest.TestCase):
     def which(cls, cmd):
         try:
             from xpra.os_util import get_status_output
-            code, out, _ = get_status_output(["which", cmd])
+            code, out, _ = get_status_output(["command -v", cmd])
             if code==0:
                 return out.splitlines()[0]
         except OSError:

--- a/xpra/net/ssh.py
+++ b/xpra/net/ssh.py
@@ -810,12 +810,12 @@ def paramiko_run_remote_xpra(transport, xpra_proxy_command=None, remote_xpra=Non
             #assume this path exists
             pass
         else:
-            #assume Posix and find that command:
-            r = rtc("which %s" % xpra_cmd)
+            #assume POSIX and find that command:
+            r = rtc("command -v %s" % xpra_cmd)
             if r[2]!=0:
                 continue
             if r[0]:
-                #use the actual path returned by 'which':
+                #use the actual path returned by 'command -v':
                 try:
                     xpra_cmd = r[0].decode().splitlines()[-1].rstrip("\n\r ").lstrip("\t ")
                 except Exception:
@@ -890,8 +890,8 @@ def ssh_exec_connect_to(display_desc, opts=None, debug_cb=None, ssh_fail_cb=ssh_
             else:
                 check = "elif"
             if x=="xpra":
-                #no absolute path, so use "which" to check that the command exists:
-                pc = ['%s which "%s" > /dev/null 2>&1; then' % (check, x)]
+                #no absolute path, so use "command -v" to check that the command exists:
+                pc = ['%s command -v "%s" > /dev/null 2>&1; then' % (check, x)]
             else:
                 pc = ['%s [ -x %s ]; then' % (check, x)]
             pc += [x] + proxy_command + [shellquote(x) for x in display_as_args]

--- a/xpra/server/server_util.py
+++ b/xpra/server/server_util.py
@@ -154,7 +154,7 @@ def xpra_runner_shell_script(xpra_file, starting_dir, socket_dir):
             sexec = os.path.join(sexec[:bini], "Resources", "MacOS", "Xpra")
         script.append(b"_XPRA_SCRIPT=%s\n" % (sh_quotemeta(sexec.encode()),))
         script.append(b"""
-if which "$_XPRA_SCRIPT" > /dev/null; then
+if command -v "$_XPRA_SCRIPT" > /dev/null; then
     # Happypath:
     exec "$_XPRA_SCRIPT" "$@"
 else
@@ -166,7 +166,7 @@ fi
         script.append(b"_XPRA_PYTHON=%s\n" % (sh_quotemeta(sys.executable.encode()),))
         script.append(b"_XPRA_SCRIPT=%s\n" % (sh_quotemeta(xpra_file.encode()),))
         script.append(b"""
-if which "$_XPRA_PYTHON" > /dev/null && [ -e "$_XPRA_SCRIPT" ]; then
+if command -v "$_XPRA_PYTHON" > /dev/null && [ -e "$_XPRA_SCRIPT" ]; then
     # Happypath:
     exec "$_XPRA_PYTHON" "$_XPRA_SCRIPT" "$@"
 else

--- a/xpra/server/ssh.py
+++ b/xpra/server/ssh.py
@@ -147,8 +147,8 @@ class SSHServer(paramiko.ServerInterface):
             cmd = shlex.split(bytestostr(command))
         log("check_channel_exec_request: cmd=%s", cmd)
         # not sure if this is the best way to handle this, 'command -v xpra' has len=3
-        if cmd[0] in ("type", "which", "command") and (len(cmd)==2 or len(cmd)==3):
-            xpra_cmd = cmd[1]   #ie: $XDG_RUNTIME_DIR/xpra/run-xpra or "xpra"
+        if cmd[0] in ("type", "which", "command") and len(cmd) in (2,3):
+            xpra_cmd = cmd[-1]   #ie: $XDG_RUNTIME_DIR/xpra/run-xpra or "xpra"
             if not POSIX:
                 assert WIN32
                 #we can't execute "type" or "which" on win32,

--- a/xpra/server/ssh.py
+++ b/xpra/server/ssh.py
@@ -146,7 +146,8 @@ class SSHServer(paramiko.ServerInterface):
         except UnicodeDecodeError:
             cmd = shlex.split(bytestostr(command))
         log("check_channel_exec_request: cmd=%s", cmd)
-        if cmd[0] in ("type", "which") and len(cmd)==2:
+        # not sure if this is the best way to handle this, 'command -v xpra' has len=3
+        if cmd[0] in ("type", "which", "command") and (len(cmd)==2 or len(cmd)==3):
             xpra_cmd = cmd[1]   #ie: $XDG_RUNTIME_DIR/xpra/run-xpra or "xpra"
             if not POSIX:
                 assert WIN32


### PR DESCRIPTION
Xpra currently depends on the tool `which` to be installed to find its own binary on a server. The resulting error message is not helpful as it claims the Xpra binary was not found (i.e. Xpra is not installed when it clearly is), but instead it is the binary-to-find-binaries that was not found. 

On Archlinux for example `which` is not installed by default and `which` in general has different output on different distributions. 

Using `command -v` is POSIX compliant (`which` is not) and will work on every distribution without requiring to have `which` installed. It is also the endorsed way to find the path to a binary in $PATH. 

This PR should fix this (I only tested it on Archlinux). 