### PR TITLE
accept GBRP9LE via swscale

### DIFF
--- a/xpra/codecs/codec_constants.py
+++ b/xpra/codecs/codec_constants.py
@@ -48,10 +48,10 @@ PIXEL_SUBSAMPLING = {
     "YUV422P"   : ((1, 1), (2, 1), (2, 1)),
     "YUV444P"   : ((1, 1), (1, 1), (1, 1)),
     "GBRP"      : ((1, 1), (1, 1), (1, 1)),
+    "GBRP9LE"   : ((1, 1), (1, 1), (1, 1)),
     "GBRP10"    : ((1, 1), (1, 1), (1, 1)),
     "YUV444P10" : ((1, 1), (1, 1), (1, 1)),
     "YUV444P16" : ((1, 1), (1, 1), (1, 1)),
-    "GBRP9LE"   : ((1, 1), (1, 1), (1, 1)),
 }
 def get_subsampling_divs(pixel_format):
     # Return size dividers for the given pixel format

--- a/xpra/codecs/csc_swscale/colorspace_converter.pyx
+++ b/xpra/codecs/csc_swscale/colorspace_converter.pyx
@@ -106,7 +106,7 @@ FORMAT_OPTIONS = [
     ("YUV422P", AV_PIX_FMT_YUV422P,    (1, 0.5, 0.5, 0),   (1, 1, 1, 0),       "YUV422P"),
     ("YUV444P", AV_PIX_FMT_YUV444P,    (1, 1, 1, 0),       (1, 1, 1, 0),       "YUV444P"),
     ("GBRP",    AV_PIX_FMT_GBRP,       (1, 1, 1, 0),       (1, 1, 1, 0),       "GBRP"   ),
-    ("GBRP9LE", AV_PIX_FMT_GBRP9LE,    (1, 1, 0, 0),       (1, 1, 1, 0),       "GBRP9LE"),
+    ("GBRP9LE", AV_PIX_FMT_GBRP9LE,    (1, 1, 1, 0),       (1, 1, 1, 0),       "GBRP9LE"),
     ("NV12",    AV_PIX_FMT_NV12,       (1, 1, 0, 0),       (1, 0.5, 0, 0),     "NV12"   ),
      ]
 FORMATS = {}
@@ -130,7 +130,7 @@ BYTES_PER_PIXEL = {
     AV_PIX_FMT_ARGB     : 4,
     AV_PIX_FMT_BGRA     : 4,
     AV_PIX_FMT_GBRP     : 1,
-    AV_PIX_FMT_GBRP9LE  : 2, #todo: check
+    AV_PIX_FMT_GBRP9LE  : 2,
     }
 
 

--- a/xpra/codecs/dec_avcodec2/decoder.pyx
+++ b/xpra/codecs/dec_avcodec2/decoder.pyx
@@ -515,9 +515,9 @@ FORMAT_TO_ENUM = {
             "ARGB"      : AV_PIX_FMT_ARGB,
             "BGRA"      : AV_PIX_FMT_BGRA,
             "GBRP"      : AV_PIX_FMT_GBRP,
+            "GBRP9LE"   : AV_PIX_FMT_GBRP9LE,
             "GBRP10"    : AV_PIX_FMT_GBRP10LE,
             "YUV444P10" : AV_PIX_FMT_YUV444P10LE,
-            "GBRP9LE"   : AV_PIX_FMT_GBRP9LE,
             }
 #for planar formats, this is the number of bytes per channel
 BYTES_PER_PIXEL = {


### PR DESCRIPTION
This adds GBRP9LE to the list of pixel formats which xpra with decode.

Post ffmpeg 4.4, lbavcodec outputs GBRP9LE when decoding from BGRX,
which was not supported, causing client errors, eg:

    2021-08-25 22:08:13,048 Warning: client decoding error:
    2021-08-25 22:08:13,048  video decoder avcodec failed to decode 10128 bytes of h264 data
    2021-08-25 22:08:13,051 client   7 @06.343 unknown output pixel format: GBRP9LE, expected BGR0 for 'BGRX'

GBRP9LE is planar GBR 4:4:4 27bpp, little-endian

Adding it as a format handled by swscale lets client decode without
errors; but faster solutions may be desired.

Note: this patch makes assumptions about pixel subsampling, scaling and
bytes-per-pixel