### PR TITLE
Allow for duplicate IP addresses in net_util_test

### DIFF
--- a/tests/unittests/unit/net/net_util_test.py
+++ b/tests/unittests/unit/net/net_util_test.py
@@ -6,6 +6,7 @@
 
 import unittest
 
+from collections import defaultdict
 from xpra.net.net_util import (
     get_info, get_interfaces, get_interfaces_addresses, #get_interface,
     get_gateways, get_bind_IPs, do_get_bind_ifacemask,
@@ -26,11 +27,8 @@ class TestVersionUtilModule(unittest.TestCase):
         ifaces = get_interfaces()
         if not ifaces:
             return
+        ip_ifaces = defaultdict(list)
         for iface in ifaces:
-            ipmasks = do_get_bind_ifacemask(iface)
-            for ip, _ in ipmasks:
-                assert get_iface(ip)==iface, "expected interface %s for ip %s but got %s" % (
-                    iface, ip, get_iface(ip))
             if if_nametoindex:
                 try:
                     i = if_nametoindex(iface)
@@ -40,6 +38,12 @@ class TestVersionUtilModule(unittest.TestCase):
                     if if_indextoname:
                         assert if_indextoname(i)==iface, "expected interface %s for index %i but got %s" % (
                             iface, i, if_indextoname(i))
+            ipmasks = do_get_bind_ifacemask(iface)
+            for ip, _ in ipmasks:
+                ip_ifaces[ip].append(iface)
+        for ip, ifaces in ip_ifaces:
+            assert get_iface(ip) in ifaces, "expected interface for ip %s to be one of %s but got %s" % (
+                    ip, ifaces, get_iface(ip))
         ia = get_interfaces_addresses()
         assert ia
         #for iface, address in ia.items():


### PR DESCRIPTION
It is valid for the same IP address to exist on multiple network interfaces.