### PR TITLE
GTK smooth scroll: Mirror logic from 4.2.x

### DIFF
--- a/xpra/client/gtk_base/gtk_client_window_base.py
+++ b/xpra/client/gtk_base/gtk_client_window_base.py
@@ -32,7 +32,7 @@ from xpra.gtk_common.gtk_util import (
     enable_alpha,
     gio_File, query_info_async, load_contents_async, load_contents_finish,
     WINDOW_POPUP, WINDOW_TOPLEVEL, GRAB_STATUS_STRING, GRAB_SUCCESS,
-    SCROLL_UP, SCROLL_DOWN, SCROLL_LEFT, SCROLL_RIGHT,
+    SCROLL_UP, SCROLL_DOWN, SCROLL_LEFT, SCROLL_RIGHT, SCROLL_SMOOTH,
     DEST_DEFAULT_MOTION, DEST_DEFAULT_HIGHLIGHT, ACTION_COPY,
     BUTTON_PRESS_MASK, BUTTON_RELEASE_MASK, POINTER_MOTION_MASK,
     POINTER_MOTION_HINT_MASK, ENTER_NOTIFY_MASK, LEAVE_NOTIFY_MASK,
@@ -2121,7 +2121,8 @@ class GTKClientWindowBase(ClientWindowBase, gtk.Window):
     def _do_scroll_event(self, event):
         if self._client.readonly:
             return
-        if SMOOTH_SCROLL_MASK and event.direction==SMOOTH_SCROLL_MASK:
+        if ((SMOOTH_SCROLL_MASK and event.direction==SMOOTH_SCROLL_MASK) or
+            (SCROLL_SMOOTH and event.direction==SCROLL_SMOOTH)):
             mouselog("smooth scroll event: %s", event)
             self._client.wheel_event(self._id, event.delta_x, -event.delta_y)
             return

--- a/xpra/gtk_common/gtk_util.py
+++ b/xpra/gtk_common/gtk_util.py
@@ -322,6 +322,7 @@ if is_gtk3():
     SCROLL_DOWN     = gdk.ScrollDirection.DOWN
     SCROLL_LEFT     = gdk.ScrollDirection.LEFT
     SCROLL_RIGHT    = gdk.ScrollDirection.RIGHT
+    SCROLL_SMOOTH   = gdk.ScrollDirection.SMOOTH
 
     ORIENTATION_HORIZONTAL = gtk.Orientation.HORIZONTAL
     ORIENTATION_VERTICAL = gtk.Orientation.VERTICAL
@@ -627,6 +628,7 @@ else:
     SCROLL_DOWN     = gdk.SCROLL_DOWN
     SCROLL_LEFT     = gdk.SCROLL_LEFT
     SCROLL_RIGHT    = gdk.SCROLL_RIGHT
+    SCROLL_SMOOTH   = 0
 
     ORIENTATION_HORIZONTAL = gtk.ORIENTATION_HORIZONTAL
     ORIENTATION_VERTICAL = gtk.ORIENTATION_VERTICAL


### PR DESCRIPTION
On my Debian machine, it appears that GTK is generating smooth scroll
events with the `direction` set to `ScrollDirection.SMOOTH`, which is
separate from the value being used for the mask. Without this change,
smooth scrolling does not work on my computer.