### PR TITLE
The socket directories override from CLI is not necessary, because:

### DIFF
--- a/fs/lib/systemd/system/xpra-nosocketactivation.service
+++ b/fs/lib/systemd/system/xpra-nosocketactivation.service
@@ -10,7 +10,7 @@ EnvironmentFile=-/etc/default/xpra
 ExecStart=/usr/bin/xpra proxy :14500 --daemon=no \
     --bind-tcp=0.0.0.0:14500 --tcp-auth=${TCP_AUTH} \
     --ssl-cert=/etc/xpra/ssl-cert.pem --ssl=on \
-    --bind=/run/xpra/system --auth=${AUTH} --socket-dirs=/run/xpra --socket-permissions=666 \
+    --bind=/run/xpra/system --auth=${AUTH} --socket-permissions=666 \
     --log-dir=/var/log --pidfile=/run/xpra/proxy.pid --debug=${DEBUG}
 #rely on SIGKILL which returns 128+15=143
 SuccessExitStatus=0 143

--- a/fs/lib/systemd/system/xpra.service
+++ b/fs/lib/systemd/system/xpra.service
@@ -11,7 +11,7 @@ EnvironmentFile=-/etc/sysconfig/xpra
 ExecStart=/usr/bin/xpra proxy :14500 --daemon=no \
     --tcp-auth=${TCP_AUTH} \
     --ssl-cert=/etc/xpra/ssl-cert.pem --ssl=on \
-    --bind=none --auth=${AUTH} --socket-dirs=/run/xpra --socket-permissions=666 \
+    --bind=none --auth=${AUTH} --socket-permissions=666 \
     --log-dir=/var/log --pidfile=/run/xpra/proxy.pid --debug=${DEBUG}
 #rely on SIGKILL which returns 128+15=143
 SuccessExitStatus=0 143


### PR DESCRIPTION
  * Socket-activated Xpra proxy server listens on TCP port 14500,
    and does not bind to any Unix domain socket via `-bind=none`.

  * Non-socket-activated Xpra proxy server listens on TCP port 14500
    and does bind on `/run/xpra/system` domain socket via
    `--bind=/run/xpra/system`.

The negative side effect of restricting `DotXpra.socket_details`
to search only in `/run/xpra` is that existing sockets in
`$XDG_RUNTIME_DIR/xpra` can not be found by `make_authenticators`,
so remote user can not re-attach to existing Xpra backend server
via proxy.

Signed-off-by: Vasyl Gello <vasek.gello@gmail.com>
