### PR TITLE
Fix data race between send_updated_menu and send_initial_data

### DIFF
--- a/xpra/server/mixins/child_command_server.py
+++ b/xpra/server/mixins/child_command_server.py
@@ -151,14 +151,11 @@ class ChildCommandServer(StubServerMixin):
         if ss.xdg_menu_update:
             #this method may block if the menus are still being loaded,
             #so do it in a throw-away thread:
-            start_thread(self.send_xdg_menu_data, "send-xdg-menu-data", True, (ss,))
+            start_thread(self.prepare_xdg_menu_data, "send-xdg-menu-data", True, ())
 
-    def send_xdg_menu_data(self, ss):
-        if ss.is_closed():
-            return
+    def prepare_xdg_menu_data(self):
         xdg_menu = self._get_xdg_menu_data() or {}
-        log("%i entries sent in initial data", len(xdg_menu))
-        ss.send_setting_change("xdg-menu", xdg_menu)
+        log("%i entries prepared", len(xdg_menu))
 
     def send_updated_menu(self, xdg_menu):
         log("send_updated_menu(%s)", ellipsizer(xdg_menu))


### PR DESCRIPTION
The preparation of XDG menu dat still takes place in separate thread,
but since 'send_updated_menu' callback is fired every time XDG menu
provider completes reloading, sending the 'xdg_menu' from
'send_initial_data' is redundant and introduces a data race:

> send_initial_data: thread of 'send_xdg_menu_data' is started
 > menu provider finishes loading XDG data and triggers 'send_updated_menu'
 > The proper menu is sent from 'send_updated_menu'
> send_xdg_menu_data in thread sends empty array to client

Depending on which thread wins, HTML5 client receives either non-empty
or empty array as **the last**.
