### PR TITLE
nvenc encoder improvements - support a common backing encoding session across windows

### DIFF
--- a/xpra/codecs/nvenc/encoder.pyx
+++ b/xpra/codecs/nvenc/encoder.pyx
@@ -3328,7 +3328,7 @@ cdef class Encoder:
             msg = "could not open encode session: %s" % (nvencStatusInfo(r) or r)
             log(msg)
             
-            if r == 10:
+            if r == NV_ENC_ERR_OUT_OF_MEMORY:
                 log("dumping lib refs and reloading")
                 global NvEncodeAPICreateInstance, cuCtxGetCurrent
                 NvEncodeAPICreateInstance = None

--- a/xpra/codecs/nvenc/encoder.pyx
+++ b/xpra/codecs/nvenc/encoder.pyx
@@ -1575,9 +1575,9 @@ cdef class UniqueEncoder:
         return Encoder.instance().is_ready()
 
 
-    def compress_image(self, device_context, image, int quality=-1, int speed=-1, options=None, int retry=0):
+    def compress_image(self, image, options=None, int retry=0):
         log("called compress_image with unique_encoder: %s, frames: %i, self id: %i", self, self.frames, id(self))
-        return self.base_encoder().compress_image(device_context, image, quality=quality, speed=speed, options=options, retry=retry, unique_id=id(self))
+        return self.base_encoder().compress_image(image, options=options, retry=retry, unique_id=id(self))
     
     def clean(self, actualClean=False, derefOnly=False):
         Encoder.remove_child(self)
@@ -2670,7 +2670,7 @@ cdef class Encoder:
         assert cuda_device_context, "no cuda device context"
         #cuda_device_context.__enter__ does self.context.push()
         log("called compress_image with common encoder: %s, context: %#x, frames: %i", self, <uintptr_t> self.context, self.frames)
-        log("compress_image%s", (device_context, quality, speed, options, retry))
+        log("compress_image%s", (cuda_device_context, options, retry))
 
         #FIXME: do not lock encode_lock on USE_SINGLETON_ENCODER disabled
         global encode_lock

--- a/xpra/codecs/nvenc/encoder.pyx
+++ b/xpra/codecs/nvenc/encoder.pyx
@@ -3440,6 +3440,7 @@ def init_module():
             #obtain a new cdc, since the previous one could be invalid
             cdc = cuda_device_context(device_id, device)
             with cdc as device_context:
+                options["cuda-device-context"] = cdc
                 test_encodings = []
                 for e in TEST_ENCODINGS:
                     if e in FAILED_ENCODINGS:

--- a/xpra/server/window/window_video_source.py
+++ b/xpra/server/window/window_video_source.py
@@ -1242,9 +1242,12 @@ class WindowVideoSource(WindowSource):
                      force_reload, ve.get_src_format(), enc_in_format)
             clean = True
         elif ve.get_width()!=enc_width or ve.get_height()!=enc_height:
-            scorelog("check_pipeline_score(%s) change of video input dimensions from %ix%i to %ix%i",
-                     force_reload, ve.get_width(), ve.get_height(), enc_width, enc_height)
-            clean = True
+            if hasattr(ve, 'can_ignore_dim_changes') and ve.can_ignore_dim_changes():
+                pass
+            else:
+                scorelog("check_pipeline_score(%s) change of video input dimensions from %ix%i to %ix%i",
+                        force_reload, ve.get_width(), ve.get_height(), enc_width, enc_height)
+                clean = True
         elif not isinstance(ve, encoder_spec.codec_class):
             scorelog("check_pipeline_score(%s) found a better video encoder class than %s: %s",
                      force_reload, type(ve), scores[0])
@@ -1677,9 +1680,12 @@ class WindowVideoSource(WindowSource):
                                             ve.get_encoding(), csv(encodings))
             return False
         if ve.get_width()!=encoder_src_width or ve.get_height()!=encoder_src_height:
-            videolog("do_check_pipeline video: window dimensions have changed from %sx%s to %sx%s",
-                                            ve.get_width(), ve.get_height(), encoder_src_width, encoder_src_height)
-            return False
+            if hasattr(ve, 'can_ignore_dim_changes') and ve.can_ignore_dim_changes():
+                pass
+            else: 
+                videolog("do_check_pipeline video: window dimensions have changed from %sx%s to %sx%s",
+                                                ve.get_width(), ve.get_height(), encoder_src_width, encoder_src_height)
+                return False
         return True
 
 

--- a/xpra/server/window/window_video_source.py
+++ b/xpra/server/window/window_video_source.py
@@ -326,6 +326,8 @@ class WindowVideoSource(WindowSource):
         super().cleanup()
         self.cleanup_codecs()
 
+        self.cuda_device_context = None
+        
     def cleanup_codecs(self):
         """ Video encoders (x264, nvenc and vpx) and their csc helpers
             require us to run cleanup code to free the memory they use.
@@ -1797,6 +1799,8 @@ class WindowVideoSource(WindowSource):
             options["scaled-width"] = enc_width*n//d
             options["scaled-height"] = enc_height*n//d
         options["dst-formats"] = dst_formats
+        if self.cuda_device_context:
+            options["cuda-device-context"] = self.cuda_device_context
 
         ve.init_context(encoder_spec.encoding, enc_width, enc_height, enc_in_format, options)
         #record new actual limits:
@@ -2251,6 +2255,7 @@ class WindowVideoSource(WindowSource):
 
         start = monotonic()
         options.update(self.get_video_encoder_options(ve.get_encoding(), width, height))
+        options["cuda-device-context"] = self.cuda_device_context
         try:
             ret = ve.compress_image(csc_image, options)
         except Exception as e:

--- a/xpra/server/window/window_video_source.py
+++ b/xpra/server/window/window_video_source.py
@@ -8,6 +8,7 @@ import os
 import time
 import operator
 import traceback
+import threading
 from math import sqrt
 from functools import reduce
 from time import monotonic
@@ -864,6 +865,7 @@ class WindowVideoSource(WindowSource):
             This runs in the UI thread.
         """
         log("process_damage_region%s", (damage_time, x, y, w, h, coding, options, flush))
+        assert self.ui_thread == threading.current_thread()
         assert coding is not None
         rgb_request_time = monotonic()
         image = self.get_damage_image(x, y, w, h)


### PR DESCRIPTION
The current implementation of the nvenc encoder instantiates a new encoding session for each new window or when a window's nvenc video encoder switches to being used. This incurs a (known) setup time each time the encoder is used and prioritized below other encoders. Due to the frequent setup and tear down, the encoder often gets into an unrecoverable state without killing xpra and restarting likely due to 2 reasons:
- **NVIDIA allows only 2 simultaneous encoders** - if 3+ windows are attempting to use the nvenc encoder on a single consumer device, only 2 will ever succeed
- **resources not being freed consistently** - the cuda/nvenc libraries are very sensitive to this and can hold on to an unusable encoder for the duration of xpra running, often completely locking up the nvenc encoder when both available encoders are orphaned

This PR solves the 2 issues above, and in the process adds a few additional benefits:
- **nvenc/hardware accelerated video encoding can easily be done on more than 2 windows simultaneously** since only one encoding session is used
- Due to using a singleton/global encoder, we can **assume a near-zero setup time** allowing more frequent use of the encoder in cases where it would have made more sense to use other encoders
- With the flexibilty of the above, we can **hint the window in focus to always prioritize using the nvenc encoder** for all encoding to keep latency at a minimum

These changes do incur some minor drawbacks however:
- **More frequent IDR keyframes are sent.** Encoding sessions retain state between frame compression except for keyframes (IDR frames). In order to not create image corruption, when the single encoder session is processing images for different windows simultaneously, it needs to send IDR frames more frequently to "reset" the encoding session. The positive side here is that the IDR frame is much faster to compress relative to subsequent frames but at the expense of a much larger size relative - incurring an overall higher bandwidth usage. This is minimized as much as possible though, and if only a single window is using the video encoder it will behave as expected (single IDR frame 0 at the beginning of the encode stream).
- **One large window will slow encoding for smaller windows.** Encoding sessions need to specify dimensions. When a frame is encountered that is larger than the current encoder's dimensions, this will resize the encoder sessions dimensions to be larger. This takes a performance hit on encoding speed for windows that do not need the larger dimension as they still compress the frame with a larger input/output buffer and dimensions. In this implementation, we never resize the encoder back down to an optimum size after the larger window is no longer needed (until xpra is restarted and the encoder is reinitialized). This can easily be fixed in the future by resizing the encoder back down if it no longer needs to render a frame that large.
- **Realtime bandwidth/speed tuning is likely ignored after initialization.** I didn't investigate this much yet, but optimization for changing link speeds/quality is likely ignored for now. This can probably be fixed fairly easily.


**High Level Implementation:**

To minimize code changes, the `Encoder` class is kept mostly intact and can act as a (previous behavior) standalone Encoder reinitialized for each window or as a common singleton instance (abstracted through the `UniqueEncoder` class). There's some python trickery here to transparently pass method calls/variable access from `UniqueEncoder` down to its backing singleton instance thus not requiring any complex rework into how a video encoder is initialized/called. This also allows selective override of any methods/variables in `UniqueEncoder` to override behavior and/or store local data to each `UniqueEncoder`.

Each `UniqueEncoder` has a `unique_id` - this id is used by the singleton `Encoder`'s `compress_image` to determine if it needs to reset the backing encoder session back to frame 0 and send an IDR frame.

`compress_image` checks if the encoder is large enough to render the frame, and if not - triggers a resize of the encoding session (without fully reinitializing it) before continuing on to compress the image.

When `clean()` is called on a `UniqueEncoder` we need to ignore this, as we don't want to cleanup the singleton `Encoder` since it's likely to be used by a future `UniqueEncoder`.

**Notes:**
- Some errors indicate a likely lockup with the encoding session - these when detected will trigger a full reinitialization of the nvenc library or singleton encoder instance, usually successfully recovering within a few seconds.
- A global `encode_lock` is used to ensure parallel `compress_image` calls don't step over each other since they will be using the same backing buffers for IO to the encoder session.
- New environment variable config flags are added:
  - `XPRA_WINDOW_FOCUS_VIDEO_ENCODER` - if `True` try to use the video encoder for all frames of a window in focus, regardless of other hints that would exclude it from using the video encoder (ie text content-type)
  - `XPRA_NVENC_USE_SINGLETON_ENCODER` - if `True` use this PR's implementation of a single backing encoder session for all windows, otherwise use the one encoder session per window implementation
- This PR disables threaded init by default, as I had found (before these changes) that it was much more reliable when not initialized in a separate thread and this PR has only been tested with single-threaded init. In addition, threaded init is likely not even needed anymore for a singleton instance since init will happen very infrequently.