### PR TITLE
run_scaled: support passing arguments to Xpra

### DIFF
--- a/fs/bin/run_scaled
+++ b/fs/bin/run_scaled
@@ -67,15 +67,16 @@ def get_screen_spec():
 #default value:
 scale = 2
 command_argv = []
+extra_xpra_args = None
 
-# Split at last "--" and pass the args after that to Xpra
+# If "--" is present, the command is after that
 if "--" in sys.argv:
-    split_ridx = sys.argv[::-1].index("--")
-    args = sys.argv[1:-split_ridx-1]
-    extra_xpra_args = sys.argv[-split_ridx:]
+    split_idx = sys.argv.index("--")
+    args = sys.argv[1:split_idx]
+    command_argv = sys.argv[split_idx+1:]
+    extra_xpra_args = []
 else:
     args = sys.argv[1:]
-    extra_xpra_args = []
 
 for i, x in enumerate(args):
     if x in ("--help", "-h"):
@@ -83,7 +84,10 @@ for i, x in enumerate(args):
     elif x.startswith("--scale="):
         scale = parse_scale(x[len("--scale="):])
     else:
-        command_argv.append(x)
+        if extra_xpra_args is None:
+            command_argv.append(x)
+        else:
+            extra_xpra_args.append(x)
 if not command_argv:
     usage("missing command argument")
 
@@ -103,7 +107,9 @@ xpra_argv = [
     "--encodings=rgb",
     "--compress=0",
     "--systemd-run=no",
-    ] + extra_xpra_args
+    ]
+if extra_xpra_args:
+    xpra_argv += extra_xpra_args
 
 width, height, dpi = get_screen_spec()
 #if found, prefer Xvfb, as it is faster to startup:

--- a/fs/share/man/man1/run_scaled.1
+++ b/fs/share/man/man1/run_scaled.1
@@ -14,7 +14,10 @@ run_scaled - run an X11 application upscaled or downscaled
 .PD 0
 .HP \w'run_scaled\ 'u
 \fBrun_scaled\fP
-[\fB--scale\fP=\fIVALUE\fP] application [application-arguments] [\fB--\fP] [xpra-arguments]\fB
+[\fB--scale\fP=\fIVALUE\fP] application [application-arguments]
+.HP \w'run_scaled\ 'u
+\fBrun_scaled\fP
+[\fB--scale\fP=\fIVALUE\fP] [xpra-arguments] \fB--\fP application [application-arguments]
 .PD
 
 .\" --------------------------------------------------------------------
@@ -33,7 +36,7 @@ The xterm window will be twice as big as it normally would be.
 \fBrun_scaled --scale=250% firefox\fP
 Start firefox, upscaled by 250%.
 .TP
-\fBrun_scaled wine notepad.exe -- --speaker=off --microphone=off\fP
+\fBrun_scaled --speaker=off --microphone=off -- wine notepad.exe\fP
 Starts the command "\fBwine notepad.exe\fP", with audio inputs and outputs disabled (by additional Xpra arguments) and the default scaling of \fB2\fP.
 
 .\" --------------------------------------------------------------------


### PR DESCRIPTION
I needed to pass some arguments to Xpra when running Wine software with `run_scaled`. I think this might have other use cases than mine, so I added support for passing generic extra arguments.

While I was at it, I fixed a bug in the manpage.