### PR TITLE
only use parameters from ~/.ssh/config if not explicitly specified

### DIFF
--- a/xpra/net/ssh.py
+++ b/xpra/net/ssh.py
@@ -202,12 +202,14 @@ def ssh_paramiko_connect_to(display_desc):
             if host_config:
                 log("got host config for '%s': %s", host, host_config)
                 host = host_config.get("hostname", host)
-                username = host_config.get("user", username)
-                port = host_config.get("port", port)
-                try:
-                    port = int(port)
-                except (TypeError, ValueError):
-                    raise InitExit(EXIT_SSH_FAILURE, "invalid ssh port specified: '%s'" % port) from None
+                if "username" not in display_desc:
+                    username = host_config.get("user", username)
+                if "ssh-port" not in display_desc:
+                    port = host_config.get("port", port)
+                    try:
+                        port = int(port)    
+                    except (TypeError, ValueError):
+                        raise InitExit(EXIT_SSH_FAILURE, "invalid ssh port specified: '%s'" % port) from None
                 proxycommand = host_config.get("proxycommand")
                 if proxycommand:
                     log("found proxycommand='%s' for host '%s'", proxycommand, host)


### PR DESCRIPTION
Currently, Xpra ignores the username and hostname specified in ~/.ssh/config. Because of that host aliases do not work at all, and username should also be explicitly set if it differs from the one on the client:

<details>
  <summary>Debug output and stacktrace</summary>
<pre>
2021-10-25 23:05:27,566 parsed user config '/home/egor/.ssh/config'
2021-10-25 23:05:27,566 3 hosts found
2021-10-25 23:05:27,567 got host config for 'myhostname': {'hostname': 'myhostname.example.com', 'user': 'ubuntu', 'forwardx11': 'yes', 'compression': 'yes'}
2021-10-25 23:05:27,598 progress(100, failure: cannot get  address of('myhostname', 22): [Errno -3] Временный сбой в разрешении имен)
2021-10-25 23:05:27,598 run_mode error
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/xpra/scripts/main.py", line 2408, in run_remote_server
    conn = connect_or_fail(params, opts)
  File "/usr/lib/python3/dist-packages/xpra/scripts/main.py", line 1195, in connect_or_fail
    return connect_to(display_desc, opts)
  File "/usr/lib/python3/dist-packages/xpra/scripts/main.py", line 1285, in connect_to
    return ssh_paramiko_connect_to(display_desc)
  File "/usr/lib/python3/dist-packages/xpra/net/ssh.py", line 393, in ssh_paramiko_connect_to
    sock = socket_connect(dtype, host, port)
  File "/usr/lib/python3/dist-packages/xpra/scripts/main.py", line 1218, in socket_connect
    raise InitException("cannot get %s address of%s: %s" % ({
xpra.scripts.config.InitException: cannot get  address of('myhostname', 22): [Errno -3] Временный сбой в разрешении имен

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/xpra/scripts/main.py", line 130, in main
    return run_mode(script_file, err, options, args, mode, defaults)
  File "/usr/lib/python3/dist-packages/xpra/scripts/main.py", line 404, in run_mode
    return do_run_mode(script_file, error_cb, options, args, mode, defaults)
  File "/usr/lib/python3/dist-packages/xpra/scripts/main.py", line 414, in do_run_mode
    return run_remote_server(error_cb, options, args, mode, defaults)
  File "/usr/lib/python3/dist-packages/xpra/scripts/main.py", line 2413, in run_remote_server
    app.show_progress(100, "failure: %s" % e)
  File "/usr/lib/python3/dist-packages/xpra/client/client_base.py", line 172, in show_progress
    noerr(pp.stdin.write, ("%i:%s\n" % (pct, text)).encode("latin1"))
UnicodeEncodeError: 'latin-1' codec can't encode characters in position 62-70: ordinal not in range(256)
</pre>
</details>

This PR allows using username, hostname, and port from SSH config file while preserving an option to override them.

P.S. I would be glad if you put `hacktoberfest-accepted` label on this PR, so that it will be counted for [Hacktoberfest](https://hacktoberfest.digitalocean.com) :blush: