### PR TITLE
Fix libavformat does not support mp4

### DIFF
--- a/xpra/codecs/enc_ffmpeg/encoder.pyx
+++ b/xpra/codecs/enc_ffmpeg/encoder.pyx
@@ -788,7 +788,7 @@ def flagscsv(flag_dict, value=0):
 
 def get_muxer_formats():
     cdef AVOutputFormat *fmt
-    cdef void* opaque
+    cdef void *opaque = NULL
     formats = {}
     while True:
         fmt = <AVOutputFormat*> av_muxer_iterate(&opaque)
@@ -803,7 +803,7 @@ print_nested_dict(get_muxer_formats(), print_fn=log.debug)
 
 cdef AVOutputFormat* get_av_output_format(name):
     cdef AVOutputFormat *fmt
-    cdef void* opaque
+    cdef void *opaque = NULL
     while True:
         fmt = <AVOutputFormat*> av_muxer_iterate(&opaque)
         if fmt==NULL:


### PR DESCRIPTION
Fix for the errors;
ffmpeg: h264+mp4 encoding failed: libavformat does not support mp4
ffmpeg: vp8+webm encoding failed: libavformat does not support webm

The error is caused by the fact that no muxers are returned by av_muxer_iterate. The ffmpeg docs state:
_Parameters: opaque a pointer where libavformat will store the iteration state. Must point to NULL to start the iteration._


