### PR TITLE
Use shutil.which instead of "command -v" when invoking via Popen

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2061,17 +2061,9 @@ if (nvenc_ENABLED and cuda_kernels_ENABLED) or nvjpeg_ENABLED:
         path_options += list(reversed(sorted_nicely(glob.glob("/usr/local/cuda*/bin"))))
         path_options += list(reversed(sorted_nicely(glob.glob("/opt/cuda*/bin"))))
     options = [os.path.join(x, nvcc_exe) for x in path_options]
-    def which(cmd):
-        try:
-            code, out, _ = get_status_output(["command", "-v", cmd])
-            if code==0:
-                return out
-        except:
-            pass
-        return None
     #prefer the one we find on the $PATH, if any:
     try:
-        v = which(nvcc_exe)
+        v = shutil.which(nvcc_exe)
         if v and (v not in options):
             options.insert(0, v)
     except:

--- a/tests/unittests/unit/process_test_util.py
+++ b/tests/unittests/unit/process_test_util.py
@@ -5,6 +5,7 @@
 # later version. See the file COPYING for details.
 
 import os
+import shutil
 import sys
 import time
 import tempfile
@@ -177,14 +178,7 @@ class ProcessTestUtil(unittest.TestCase):
 
     @classmethod
     def which(cls, cmd):
-        try:
-            from xpra.os_util import get_status_output
-            code, out, _ = get_status_output(["command", "-v", cmd])
-            if code==0:
-                return out.splitlines()[0]
-        except OSError:
-            pass
-        return cmd
+        return shutil.which(cmd) or cmd
 
     def run_command(self, command, **kwargs):
         return self.class_run_command(command, **kwargs)


### PR DESCRIPTION
"command" is a shell built-in so you cannot call it with Popen. See #3215.

While looking at this, I noticed another implementation of `which` in `os_util.py`. Any reason not to use `shutil` here too? Is this left over from when Python 2 was supported?