### PR TITLE
Fix error that occurs when make_session_dir fallback already exists

### DIFF
--- a/xpra/scripts/server.py
+++ b/xpra/scripts/server.py
@@ -374,7 +374,7 @@ def make_session_dir(mode, sessions_dir, display_name, uid=0, gid=0):
         session_dir = osexpand(os.path.join(tempfile.gettempdir(), display_name.lstrip(":")))
         os.makedirs(session_dir, 0o750, exist_ok=True)
     ROOT = POSIX and getuid()==0
-    if ROOT and (session_dir.startswith("/run/user") or session_dir.startswith("/run/xpra")):
+    if ROOT and (session_dir.startswith("/run/user/") or session_dir.startswith("/run/xpra/")):
         os.lchown(session_dir, uid, gid)
     return session_dir
 

--- a/xpra/scripts/server.py
+++ b/xpra/scripts/server.py
@@ -367,16 +367,15 @@ def get_session_dir(mode, sessions_dir, display_name, uid):
 
 def make_session_dir(mode, sessions_dir, display_name, uid=0, gid=0):
     session_dir = get_session_dir(mode, sessions_dir, display_name, uid)
-    if not os.path.exists(session_dir):
-        try:
-            os.makedirs(session_dir, 0o750)
-        except OSError:
-            import tempfile
-            session_dir = osexpand(os.path.join(tempfile.gettempdir(), display_name.lstrip(":")))
-            os.makedirs(session_dir, 0o750)
-        ROOT = POSIX and getuid()==0
-        if ROOT and (session_dir.startswith("/run/user") or session_dir.startswith("/run/xpra")):
-            os.lchown(session_dir, uid, gid)
+    try:
+        os.makedirs(session_dir, 0o750, exist_ok=True)
+    except OSError:
+        import tempfile
+        session_dir = osexpand(os.path.join(tempfile.gettempdir(), display_name.lstrip(":")))
+        os.makedirs(session_dir, 0o750, exist_ok=True)
+    ROOT = POSIX and getuid()==0
+    if ROOT and (session_dir.startswith("/run/user") or session_dir.startswith("/run/xpra")):
+        os.lchown(session_dir, uid, gid)
     return session_dir
 
 def session_file_path(filename):


### PR DESCRIPTION
If the usual session directory cannot be created, a temporary directory is used as a fallback. However, there is no check to ensure that the fallback does not already exist, leading to an error.

Xpra requires at least Python 3.6 now, so it is okay to use Python 3.3's `exist_ok` when calling `os.makedirs`.

Following this, we now always correct the owner of the directory for consistency. This was previously skipped when the usual directory (but not the fallback) already existed.