### PR TITLE
Respect XDG_* environment variables when running tests

### DIFF
--- a/tests/unittests/unit/process_test_util.py
+++ b/tests/unittests/unit/process_test_util.py
@@ -167,6 +167,7 @@ class ProcessTestUtil(unittest.TestCase):
                     "XAUTHORITY", "PWD",
                     "PYTHONPATH", "SYSTEMROOT",
                     "DBUS_SESSION_BUS_ADDRESS",
+                    "XDG_RUNTIME_DIR",
                     ))
         log("get_default_run_env() env(%s)=%s", repr_ellipsized(cls.default_env), env)
         env["NO_AT_BRIDGE"] = "1"


### PR DESCRIPTION
Gentoo sets `XDG_RUNTIME_DIR` to an isolated directory when building and testing packages, so we don't expect test files to be written to the fallback location of `/tmp`.