### PR TITLE
opts.password_file is a list of strings, not a string itself

### DIFF
--- a/xpra/scripts/parsing.py
+++ b/xpra/scripts/parsing.py
@@ -470,8 +470,8 @@ def parse_display_name(error_cb, opts, display_name, find_session_by_name=False)
 
     def _set_password():
         password = desc.get("password")
-        if password is None:
-            password = load_password_file(opts.password_file)
+        if password is None and opts.password_file is not None and len(opts.password_file)>0:
+            password = load_password_file(opts.password_file[0])
             if password:
                 desc["password"] = password
         if password:


### PR DESCRIPTION
Note [this line](https://github.com/Xpra-org/xpra/blob/e58b25c071698846c098890a72f66671db6955cf/xpra/scripts/parsing.py#L1580), which sets the action to `append`. Admittedly I'm not sure whether this is the right fix. What is this code supposed to do when more than one password file is given?