### PR TITLE
Websocket auth

### DIFF
--- a/xpra/net/websockets/protocol.py
+++ b/xpra/net/websockets/protocol.py
@@ -47,6 +47,7 @@ class WebSocketProtocol(Protocol):
         self._process_read = self.parse_ws_frame
         self.make_chunk_header = self.make_xpra_header
         self.make_frame_header = self.make_wsframe_header
+        self.http_request = None # WebSocketRequestHandler
 
     def __repr__(self):
         return "WebSocket(%s)" % self._conn

--- a/xpra/scripts/server.py
+++ b/xpra/scripts/server.py
@@ -1339,7 +1339,7 @@ def _do_run_server(script_file, cmdline,
 
     if opts.chdir:
         log(f"chdir({opts.chdir})")
-        os.chdir(opts.chdir)
+        os.chdir(os.path.expanduser(opts.chdir))
 
     dbus_pid, dbus_env = 0, {}
     if not shadowing and POSIX and not OSX:

--- a/xpra/server/auth/exec_auth.py
+++ b/xpra/server/auth/exec_auth.py
@@ -45,7 +45,7 @@ class Authenticator(SysAuthenticator):
         super().__init__(**kwargs)
 
     def requires_challenge(self) -> bool:
-        return False
+        return bool(self.http_request)
 
     def authenticate(self, caps : typedict) -> bool:
         info = "Connection request from %s" % self.connection_str

--- a/xpra/server/auth/exec_auth.py
+++ b/xpra/server/auth/exec_auth.py
@@ -4,7 +4,9 @@
 # later version. See the file COPYING for details.
 
 import os
-from subprocess import Popen
+import base64, binascii
+from urllib.parse import urlparse
+from subprocess import Popen, DEVNULL
 from gi.repository import GLib
 
 from xpra.util import envint, typedict
@@ -12,6 +14,7 @@ from xpra.os_util import OSX
 from xpra.child_reaper import getChildReaper
 from xpra.server.auth.sys_auth_base import SysAuthenticator, log
 from xpra.platform.features import EXECUTABLE_EXTENSION
+from xpra.net.websockets.handler import WebSocketRequestHandler
 
 TIMEOUT = envint("XPRA_EXEC_AUTH_TIMEOUT", 600)
 
@@ -22,6 +25,7 @@ class Authenticator(SysAuthenticator):
         log("exec.Authenticator(%s)", kwargs)
         self.command = kwargs.pop("command", "")
         self.timeout = kwargs.pop("timeout", TIMEOUT)
+        self.http_request = kwargs.pop('http_request')
         self.timer = None
         self.proc = None
         self.timeout_event = False
@@ -50,7 +54,12 @@ class Authenticator(SysAuthenticator):
     def authenticate(self, caps : typedict) -> bool:
         info = "Connection request from %s" % self.connection_str
         cmd = [self.command, info, str(self.timeout)]
-        with Popen(cmd) as proc:
+        env = stdin = stdout = None
+        if self.http_request:
+            stdin = stdout = DEVNULL
+            env = os.environ.copy()
+            add_cgi_headers(env, self.http_request)
+        with Popen(cmd, env=env, stdin=stdin, stdout=stdout) as proc:
             self.proc = proc
             log("authenticate(..) Popen(%s)=%s", cmd, proc)
             #if required, make sure we kill the command when it times out:
@@ -87,3 +96,54 @@ class Authenticator(SysAuthenticator):
 
     def __repr__(self):
         return "exec"
+
+def add_cgi_headers(env : dict, request : WebSocketRequestHandler):
+    url = urlparse(request.path)
+    parts = url.path.rsplit('/', 1)
+    if len(parts)==1: # no '/', act as if there is a trailing '/'
+        parts = [parts, '']
+
+    # Not passing through any content
+    env['CONTENT_TYPE'] = ''
+    env['CONTENT_LENGTH'] = '0'
+
+    # see http.server.CGIHTTPRequestHandler.run_cgi()
+    # also RFC3875
+    env['SERVER_SOFTWARE'] = 'XPRA'
+    env['SERVER_PROTOCOL'] = request.protocol_version
+    env['GATEWAY_INTERFACE'] = 'CGI/1.1'
+    env['REQUEST_METHOD'] = request.command
+    env['PATH_INFO'] = parts[0]
+    env['PATH_TRANSLATED'] = parts[0] # TODO: window-ish path?
+    env['SCRIPT_NAME'] = parts[1]
+    if url.query:
+        env['QUERY_STRING'] = url.query
+    env['REMOTE_ADDR'] = request.client_address[0]
+
+    # request.server not provided, and not that interesting anyway...
+    #env['SERVER_NAME'] = request.server.server_name
+    #env['SERVER_PORT'] = str(request.server.server_port)
+
+    agent = request.headers.get('user-agent')
+    if agent:
+        env['HTTP_USER_AGENT'] = agent
+
+    cookies = [co for co in request.headers.get_all('cookie', []) if co]
+    if cookies:
+        env['COOKIE'] = ', '.join(cookies)
+
+    auth = request.headers.get("auth", "").split()
+    if len(auth)==2 and auth[0].lower()=='basic':
+        env['AUTH_TYPE'] = 'basic'
+        try:
+            # headers originally decoded as 'iso-8859-1' by http.client.parse_headers()
+            # http.server.CGIHTTPRequestHandler.run_cgi() re-encodes them as 'ascii'
+            # we follow parse_headers().
+            # Shouldn't make any difference if payload is really base64 encoded.
+            auth = base64.decodebytes(auth[1].encode('iso-8859-1')).decode()
+            # we decode the output as utf-8 because everyone loves crazy password rules
+            env['REMOTE_USER'], env['REMOTE_IDENT'] = auth.split(':',1)
+        except (TypeError, binascii.Error, UnicodeError):
+            pass
+
+    # TODO: pass remaining headers as HTTP_* ?

--- a/xpra/server/rfb/rfb_server.py
+++ b/xpra/server/rfb/rfb_server.py
@@ -68,7 +68,7 @@ class RFBServer:
             conn.close()
             return
         def rfb_protocol_class(conn):
-            auths = self.make_authenticators("rfb", "rfb", conn)
+            auths = self.make_authenticators("rfb", "rfb", conn, None)
             assert len(auths)<=1, "rfb does not support multiple authentication modules"
             auth = None
             if len(auths)==1:

--- a/xpra/server/server_core.py
+++ b/xpra/server/server_core.py
@@ -1499,7 +1499,8 @@ class ServerCore:
                 from xpra.net.websockets.protocol import WebSocketProtocol
                 wslog("new_websocket_client(%s) socket=%s", wsh, sock)
                 newsocktype = "wss" if is_ssl else "ws"
-                self.make_protocol(newsocktype, conn, socket_options, WebSocketProtocol)
+                proto = self.make_protocol(newsocktype, conn, socket_options, WebSocketProtocol)
+                proto.http_request = wsh
             scripts = self.get_http_scripts()
             conn.socktype = "wss" if is_ssl else "ws"
             redirect_https = False


### PR DESCRIPTION
This PR has had very little testing.  At this point I'm looking for comment.  Is this a good idea/approach?  Something which could be merged?  Is there already a way to accomplish this already which I've missed?

In looking into ways to integrate authentication of an xpra html5 client with a web application I came across the nginx idea of [sub-request authentication](https://docs.nginx.com/nginx/admin-guide/security-controls/configuring-subrequest-authentication/) and wondered if this could be extended to the xpra server as well.  From what I can tell, the immediate answer is "no".  This PR is an attempt to change the situation by making a `WebSocketRequestHandler` (or `None`) available to authentication plugins.  This gives a plugin access to HTTP header information, especially [Cookie](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cookie) or [Authentication](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Authorization).

`exec_auth.py` is changed to pass some HTTP header information in the manner of a CGI script.  (informed by `http.server.CGIHTTPRequestHandler.run_cgi()`)  So that the command executed could eg. pass the requested user name and a session cookie back to a web application to authorize the request.

This is still a work in progress.  Having done so, I'm less sure that modifying `exec_auth.py` is the way to go.