### PR TITLE
move manual to subdir of /u/s/doc/xpra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1669,7 +1669,7 @@ else:
                     #keep everything in our own directory:
                     doc_dir = "%s/share/xpra/doc" % self.install_dir
                 else:
-                    doc_dir = "%s/share/doc/xpra" % self.install_dir
+                    doc_dir = "%s/share/doc/xpra/manual" % self.install_dir
                 convert_doc_dir("./docs", doc_dir)
 
             if data_ENABLED:


### PR DESCRIPTION
This helps to keep the /usr/share/doc/xpra folder
organized and is customary with Debian packages.

Otherwise a use would not know that the html
subfolders are part of the html manual when
inspecting the doc/xpra folder.