### PR TITLE
add path-check, add XPRA_SYSCONF_DIR for xposix, add XDG_DATA_DIRS/icons to search path for pixmaps

### DIFF
--- a/xpra/platform/xposix/menu_helper.py
+++ b/xpra/platform/xposix/menu_helper.py
@@ -177,8 +177,9 @@ def find_resources_icon(*names):
 def find_pixmap_icon(*names):
     if not LOAD_FROM_PIXMAPS:
         return None
+    pixmaps_dirs = [d + '/icons' for d in os.environ.get("XDG_DATA_DIRS").split(":")]
     pixmaps_dir = "%s/share/pixmaps" % sys.prefix
-    pixmaps_dirs = (pixmaps_dir, os.path.join(pixmaps_dir, "comps"))
+    pixmaps_dirs += (pixmaps_dir, os.path.join(pixmaps_dir, "comps"))
     for d in pixmaps_dirs:
         if not os.path.exists(d) or not os.path.isdir(d):
             return None

--- a/xpra/platform/xposix/menu_helper.py
+++ b/xpra/platform/xposix/menu_helper.py
@@ -411,6 +411,8 @@ def load_xdg_menu_data():
         from xdg.Menu import MenuEntry
         entries = {}
         for d in LOAD_APPLICATIONS:
+            if not os.path.exists(d):
+                continue
             for f in os.listdir(d):
                 if not f.endswith(".desktop"):
                     continue

--- a/xpra/platform/xposix/paths.py
+++ b/xpra/platform/xposix/paths.py
@@ -80,7 +80,10 @@ def do_get_script_bin_dirs():
 
 
 def do_get_system_conf_dirs():
-    dirs = ["/etc/xpra", "/usr/local/etc/xpra"]
+    if os.environ.get("XPRA_SYSCONF_DIR") is not None:
+        dirs = [os.environ.get("XPRA_SYSCONF_DIR")]
+    else:
+        dirs = ["/etc/xpra", "/usr/local/etc/xpra"]
     for d in os.environ.get("XDG_CONFIG_DIRS", "/etc/xdg").split(":"):
         dirs.append(os.path.join(d, "xpra"))
     #hope the prefix is something like "/usr/local" or "$HOME/.local":


### PR DESCRIPTION
1) The line
```
LOAD_APPLICATIONS = os.environ.get("XPRA_MENU_LOAD_APPLICATIONS", "%s/share/applications" % sys.prefix).split(":")
```
https://github.com/Xpra-org/xpra/blob/master/xpra/platform/xposix/menu_helper.py#L35
can return `None` and therefor needs to be checked for existance before use.

2) Like it is already possible for OSX ( https://github.com/Xpra-org/xpra/blob/master/xpra/platform/darwin/paths.py#L93 )
 it would help if the environment variable XPRA_SYSCONF_DIR can be used to overwrite the system default path.
 
 Example:
We have multiple installations of Xpra on the same multi-user systems of a few hpc-clusters. The user/workflow can choose which of these installations is loaded using lmod, a framework to load software when needed into the current environment.  
Xpra is therefore no real system-installations as they are installed to special directories each, and they are no user-installations as they are not installed by the user.
Hence it is needed to avoid that xpra looks at system paths (`/etc/xpra`) for configuration files. 

3) XDG_DATA_DIRS/icons should added to the search paths for icons
https://specifications.freedesktop.org/icon-theme-spec/latest/ar01s03.html