### PR TITLE
fix file upload

### DIFF
--- a/xpra/net/file_transfer.py
+++ b/xpra/net/file_transfer.py
@@ -493,7 +493,7 @@ class FileTransferHandler(FileTransferAttributes):
         check_digest("sha1", hashlib.sha1)
         check_digest("md5", hashlib.md5)
         try:
-            os.write(fd, file_data)
+            os.write(fd, strtobytes(file_data))
         finally:
             os.close(fd)
         self.transfer_progress_update(False, send_id, monotonic()-start, filesize, filesize, None)


### PR DESCRIPTION
file uploads using websocket (HTML5) client always produces a 0 byte file because file_data is a str but os.write needs bytes