### PR TITLE
add XDG_DATA_DIRS/icons to search path for pixmaps

### DIFF
--- a/xpra/platform/xposix/menu_helper.py
+++ b/xpra/platform/xposix/menu_helper.py
@@ -177,8 +177,9 @@ def find_resources_icon(*names):
 def find_pixmap_icon(*names):
     if not LOAD_FROM_PIXMAPS:
         return None
+    pixmaps_dirs = [d + '/icons' for d in os.environ.get("XDG_DATA_DIRS").split(":")]
     pixmaps_dir = "%s/share/pixmaps" % sys.prefix
-    pixmaps_dirs = (pixmaps_dir, os.path.join(pixmaps_dir, "comps"))
+    pixmaps_dirs += (pixmaps_dir, os.path.join(pixmaps_dir, "comps"))
     for d in pixmaps_dirs:
         if not os.path.exists(d) or not os.path.isdir(d):
             return None


### PR DESCRIPTION
This PR adds `$XDG_DATA_DIRS/icons` to the search paths for icons  
as mentioned in the XDG documentation here https://specifications.freedesktop.org/icon-theme-spec/latest/ar01s03.html