### PR TITLE
add path-exists check

### DIFF
--- a/xpra/platform/xposix/menu_helper.py
+++ b/xpra/platform/xposix/menu_helper.py
@@ -411,6 +411,8 @@ def load_xdg_menu_data():
         from xdg.Menu import MenuEntry
         entries = {}
         for d in LOAD_APPLICATIONS:
+            if not os.path.exists(d):
+                continue
             for f in os.listdir(d):
                 if not f.endswith(".desktop"):
                     continue


### PR DESCRIPTION
The line
```
LOAD_APPLICATIONS = os.environ.get("XPRA_MENU_LOAD_APPLICATIONS", "%s/share/applications" % sys.prefix).split(":")
```
https://github.com/Xpra-org/xpra/blob/master/xpra/platform/xposix/menu_helper.py#L35
can return a path that does not exist. Xpra needs to check its existance before use.