### PR TITLE
Fix test_get_version_info when the revision is 0

### DIFF
--- a/xpra/version_util.py
+++ b/xpra/version_util.py
@@ -158,7 +158,7 @@ def get_version_info(full=1) -> dict:
                 "branch"                : BRANCH,
                 "commit"                : COMMIT,
                 }.items():
-                if v and v!="unknown":
+                if v is not None and v!="unknown":
                     props[k] = v
         except ImportError as e:
             warn("missing some source information: %s", e)
@@ -181,7 +181,7 @@ def get_version_info_full() -> dict:
                     "cython"               : "CYTHON_VERSION",
                   }.items():
             v = getattr(build_info, bk, None)
-            if v:
+            if v is not None:
                 props[k] = v
         #record library versions:
         d = dict((k.lstrip("lib_"), getattr(build_info, k)) for k in dir(build_info) if k.startswith("lib_"))


### PR DESCRIPTION
The 4.4 tarball has revision 0, which causes it to not be included in the version info dict. Check for `not None` instead of truthiness.