### PR TITLE
Fix test_root_window_model by formatting geometry string correctly

### DIFF
--- a/xpra/server/shadow/root_window_model.py
+++ b/xpra/server/shadow/root_window_model.py
@@ -65,7 +65,7 @@ class RootWindowModel:
         self.signal_listeners = {}
 
     def __repr__(self):
-        return f"RootWindowModel({self.capture} : {self.geometry:24})"
+        return f"RootWindowModel({self.capture} : {str(self.geometry):24})"
 
     def get_info(self) -> dict:
         info = {}


### PR DESCRIPTION
You can't use `{geometry:24}` style formatting on a list or tuple. It must be converted to a string first.

Also if you meant it to look the same as `%24s`, then it should be `{str(self.geometry):>24}`. I've left that as it is though.