### PR TITLE
add GHA build/test

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,54 @@
+name: xpra
+
+on: [push, pull_request]
+
+jobs:
+  unittest:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+
+    - name: "apt-get install"
+      run: |
+        # see docs/Build/Debian.md
+        sudo apt-get update
+        sudo apt-get -y install libx11-dev libxtst-dev libxcomposite-dev libxdamage-dev libxres-dev \
+                libxkbfile-dev python-all-dev pandoc libsystemd-dev \
+                libgtk-3-dev python3-dev python3-cairo-dev python-gi-dev cython3 \
+                xauth x11-xkb-utils \
+                xvfb python3-cairo python3-gi-cairo \
+                python3-opengl python3-lz4 python3-rencode python3-pil \
+                libturbojpeg-dev libwebp-dev python3-pil \
+                libx264-dev libvpx-dev yasm \
+                python3-numpy \
+                libavformat-dev libavcodec-dev libswscale-dev \
+                python3-opengl \
+                python3-rencode python3-lz4 python3-dbus python3-cryptography \
+                python3-netifaces python3-yaml python3-lzo \
+                openssh-client sshpass python3-paramiko \
+                python3-setproctitle python3-xdg python3-pyinotify python3-opencv \
+                libpam-dev quilt xserver-xorg-dev xutils-dev xserver-xorg-video-dummy xvfb keyboard-configuration \
+                python3-kerberos python3-gssapi \
+                gstreamer1.0-pulseaudio gstreamer1.0-alsa \
+                gstreamer1.0-plugins-base gstreamer1.0-plugins-good \
+                gstreamer1.0-plugins-ugly \
+                cups-filters cups-common cups-pdf python3-cups \
+                liblz4-dev \
+                python3-coverage \
+                x11-xserver-utils dbus-x11
+
+        # tests/unittests/run wants "coverage", but debian installs as /usr/bin/python3-coverage
+        sudo ln -s /usr/bin/python3-coverage /usr/local/bin/coverage
+
+    - name: "Build/Install/Test"
+      run: >
+        python3 setup.py unittests
+        --skip-fail unit.x11.fakexinerama_test
+        --skip-fail unit.server.mixins.child_command_test
+        --skip-fail unit.server.server_sockets_test
+        --skip-fail unit.scripts.parsing_test
+        --skip-fail unit.notifications.common_test
+        --skip-slow unit.client.x11_client_test
+        --skip-slow unit.server.shadow_server_test
+        --skip-slow unit.server.mixins.start_option_test
+        --skip-slow unit.server.mixins.shadow_option_test

--- a/setup.py
+++ b/setup.py
@@ -472,8 +472,9 @@ if "pdf-doc" in sys.argv:
     convert_docs("pdf")
     sys.exit(0)
 
-if "unittests" in sys.argv:
-    os.execv("./tests/unittests/run", ["run"])
+if sys.argv[1]=="unittests":
+    os.execv("./tests/unittests/run", ["run"] + sys.argv[2:])
+assert "unittests" not in sys.argv, sys.argv
 
 
 #*******************************************************************************

--- a/tests/unittests/run
+++ b/tests/unittests/run
@@ -1,4 +1,5 @@
 #!/usr/bin/bash
+set -e
 
 die() { echo "$*" 1>&2 ; exit 1; }
 

--- a/tests/unittests/run
+++ b/tests/unittests/run
@@ -50,6 +50,6 @@ if [ "${XPRA_TEST_COVERAGE}" == "1" ]; then
 	coverage report -m
 	ls -la
 	coverage html
-	xdg-open ./htmlcov/index.html
+	[ "$GITHUB_ACTIONS" ] || xdg-open ./htmlcov/index.html
 fi
 popd

--- a/tests/unittests/unit/codecs/video_colorspace_test.py
+++ b/tests/unittests/unit/codecs/video_colorspace_test.py
@@ -109,6 +109,11 @@ class Test_CSC_Colorspace(unittest.TestCase):
             if not encoder:
                 print(f"{encoder_name} not found")
                 continue
+            try:
+                encoder.get_input_colorspaces(encoding)
+            except AssertionError:
+                print(f"{encoder_name} does not support {encoding}")
+                continue
             decoder = loader.load_codec(decoder_name)
             if not decoder:
                 print(f"{decoder_name} not found")


### PR DESCRIPTION
In looking at adding test coverage for #3471 I started by running the existing tests.  Several are not currently passing.

@totaam Do you think running tests automatically is worth pursuing at present?  I could also scale this back to only check compile/install.

```
FAIL: test_find (__main__.FakeXineramaTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/xpra/xpra/tests/unittests/unit/x11/fakexinerama_test.py", line 17, in test_find
    assert find_libfakeXinerama()
AssertionError
```

```
 ERROR: test_command_server (__main__.ChildCommandMixinTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/xpra/xpra/tests/unittests/unit/server/mixins/child_command_test.py", line 26, in test_command_server
    self.do_test_command_server()
  File "/home/runner/work/xpra/xpra/tests/unittests/unit/server/mixins/child_command_test.py", line 55, in do_test_command_server
    self._test_mixin_class(_ChildCommandServer, opts)
  File "/home/runner/work/xpra/xpra/tests/unittests/unit/server/mixins/servermixintest_util.py", line 78, in _test_mixin_class
    x = self.mixin = mclass()
  File "/home/runner/work/xpra/xpra/tests/unittests/unit/server/mixins/child_command_test.py", line 52, in _ChildCommandServer
    ccs = child_command_server.ChildCommandServer()
  File "/home/runner/work/xpra/xpra/dist/python3.8/lib/python/xpra/server/mixins/child_command_server.py", line 75, in __init__
    self.idle_add(self.late_start)
AttributeError: 'ChildCommandServer' object has no attribute 'idle_add'
```

```
error with black vp9 image via enc_vpx and dec_vpx
F
======================================================================
FAIL: test_YUV420P (__main__.Test_CSC_Colorspace)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/xpra/xpra/tests/unittests/unit/codecs/video_colorspace_test.py", line 118, in test_YUV420P
    self._test_YUV420P(encoding, encoder, decoder, yuvdata)
  File "/home/runner/work/xpra/xpra/tests/unittests/unit/codecs/video_colorspace_test.py", line 56, in _test_YUV420P
    if in_csc not in encoder_module.get_input_colorspaces(encoding):
  File "xpra/codecs/vpx/encoder.pyx", line 218, in xpra.codecs.vpx.encoder.get_input_colorspaces
AssertionError: invalid encoding: vp9
```

```
 FAIL: test_parse_image_path (__main__.TestCommon)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/work/xpra/xpra/tests/unittests/unit/notifications/common_test.py", line 30, in test_parse_image_path
    assert common.parse_image_path(filename) is not None
AssertionError
```