### PR TITLE
Added check for MSYSTEM_CARCH environment variable

### DIFF
--- a/packaging/MSWindows/MINGW_SETUP.sh
+++ b/packaging/MSWindows/MINGW_SETUP.sh
@@ -7,6 +7,10 @@
 
 set -e
 
+if [ ! -z "$MSYSTEM_CARCH" ]; then 
+	MSYSTEM_ARCH=$MSYSTEM_CARCH
+fi
+
 export XPKG="mingw-w64-${MSYSTEM_ARCH}-"
 PACMAN="pacman"
 #PACMAN="echo pacman"


### PR DESCRIPTION
In a fresh installation of Msys2 in Windows 10, the MSYSTEM_ARCH environment variable is not set, but MSYSTEM_CARCH is set in my case. This PR fixes this issue.
Regards,
San. 