### PR TITLE
fix content-type environment variable parsing

### DIFF
--- a/xpra/server/window/content_guesser.py
+++ b/xpra/server/window/content_guesser.py
@@ -92,8 +92,7 @@ def load_content_type_defs() -> dict:
         content_type_defs = _load_dict_dirs("content-type", parse_content_types)
         if GUESS_CONTENT:
             #add env defs:
-            for entries in CONTENT_TYPE_DEFS.split(","):
-                content_type_defs.update(parse_content_types(entries))
+            content_type_defs.update(parse_content_types(CONTENT_TYPE_DEFS.split(",")))
     return content_type_defs
 
 def parse_content_types(lines) -> dict:


### PR DESCRIPTION
It appeared that by using the for loop around `CONTENT_TYPE_DEFS.split(",")`, this caused the loop (over lines) in `parse_content_types` to iterate over each character instead of each "line".

This should fix that behavior.