### PR TITLE
fix focal beta component

### DIFF
--- a/packaging/repos/focal/xpra-beta.sources
+++ b/packaging/repos/focal/xpra-beta.sources
@@ -1,5 +1,5 @@
 Types: deb
 URIs: https://xpra.org/beta
 Suites: focal
-Components: focal
+Components: main
 Signed-By: /usr/share/keyrings/xpra.asc


### PR DESCRIPTION
Other sources files were already corrected in a previous commit ; but the source of the error, focal, was not fixed. :-)