### PR TITLE
Pass max buffer size to BrotliEncoderCompress

### DIFF
--- a/xpra/net/brotli/compressor.pyx
+++ b/xpra/net/brotli/compressor.pyx
@@ -91,9 +91,9 @@ def compress(data, int quality=1):
         raise Exception(f"failed to read data from {type(data)}")
     cdef const uint8_t *in_ptr = <const uint8_t*> in_buf.buf
 
-    cdef size_t out_size
+    cdef size_t out_size = max_size
     cdef int r
-    log("brotli.compress(%i bytes, %i)", in_buf.len, quality)
+    log("brotli.compress(%i bytes, %i) into %i byte buffer", in_buf.len, quality, out_size)
     try:
         with nogil:
             r = BrotliEncoderCompress(quality, BROTLI_DEFAULT_WINDOW,


### PR DESCRIPTION
The encoded_size parameter to BrotliEncoderCompress is an in/out parameter that should be initialized to the size of the output buffer.

Fixes #3824.