### PR TITLE
Fix side buttons on Win32

### DIFF
--- a/xpra/client/gtk_base/gtk_client_window_base.py
+++ b/xpra/client/gtk_base/gtk_client_window_base.py
@@ -1678,14 +1678,24 @@ class GTKClientWindowBase(ClientWindowBase, Gtk.Window):
         self.remove_pointer_overlay_timer = 0
         self.show_pointer_overlay(None)
 
+    def _button_resolve(self, button):
+        if WIN32 and button in (4, 5):
+          # On Windows "X" buttons (the extra buttons sometimes found on the
+          # side of the mouse) are numbered 4 and 5, as there is a different
+          # API for scroll events. Convert them into the X11 convention of 8
+          # and 9.
+          return button + 4
+        return button
 
     def _do_button_press_event(self, event):
         #Gtk.Window.do_button_press_event(self, event)
-        self._button_action(event.button, event, True)
+        button = self._button_resolve(event.button)
+        self._button_action(button, event, True)
 
     def _do_button_release_event(self, event):
         #Gtk.Window.do_button_release_event(self, event)
-        self._button_action(event.button, event, False)
+        button = self._button_resolve(event.button)
+        self._button_action(button, event, False)
 
     ######################################################################
     # pointer motion


### PR DESCRIPTION
Gtk on Windows maps these to buttons 4 and 5, but X11 expects them to be buttons 8 and 9. Make this conditional on Windows to avoid confusion, although as #3855 points out this isn't reachable on X11.