### PR TITLE
repos: define available architectures (amd64, arm64) for deb822-format

### DIFF
--- a/packaging/repos/bionic/xpra-beta.sources
+++ b/packaging/repos/bionic/xpra-beta.sources
@@ -3,3 +3,4 @@ URIs: https://xpra.org/beta
 Suites: bionic
 Components: main
 Signed-By: /usr/share/keyrings/xpra.asc
+Architectures: amd64 arm64

--- a/packaging/repos/bionic/xpra.sources
+++ b/packaging/repos/bionic/xpra.sources
@@ -3,3 +3,4 @@ URIs: https://xpra.org
 Suites: bionic
 Components: main
 Signed-By: /usr/share/keyrings/xpra.asc
+Architectures: amd64 arm64

--- a/packaging/repos/bookworm/xpra-beta.sources
+++ b/packaging/repos/bookworm/xpra-beta.sources
@@ -3,3 +3,4 @@ URIs: https://xpra.org/beta
 Suites: bookworm
 Components: main
 Signed-By: /usr/share/keyrings/xpra.asc
+Architectures: amd64 arm64

--- a/packaging/repos/bookworm/xpra.sources
+++ b/packaging/repos/bookworm/xpra.sources
@@ -3,3 +3,4 @@ URIs: https://xpra.org
 Suites: bookworm
 Components: main
 Signed-By: /usr/share/keyrings/xpra.asc
+Architectures: amd64 arm64

--- a/packaging/repos/bullseye/xpra-beta.sources
+++ b/packaging/repos/bullseye/xpra-beta.sources
@@ -3,3 +3,4 @@ URIs: https://xpra.org/beta
 Suites: bullseye
 Components: main
 Signed-By: /usr/share/keyrings/xpra.asc
+Architectures: amd64 arm64

--- a/packaging/repos/bullseye/xpra.sources
+++ b/packaging/repos/bullseye/xpra.sources
@@ -3,3 +3,4 @@ URIs: https://xpra.org
 Suites: bullseye
 Components: main
 Signed-By: /usr/share/keyrings/xpra.asc
+Architectures: amd64 arm64

--- a/packaging/repos/buster/xpra-beta.sources
+++ b/packaging/repos/buster/xpra-beta.sources
@@ -3,3 +3,4 @@ URIs: https://xpra.org/beta
 Suites: buster
 Components: main
 Signed-By: /usr/share/keyrings/xpra.asc
+Architectures: amd64 arm64

--- a/packaging/repos/buster/xpra.sources
+++ b/packaging/repos/buster/xpra.sources
@@ -3,3 +3,4 @@ URIs: https://xpra.org
 Suites: buster
 Components: main
 Signed-By: /usr/share/keyrings/xpra.asc
+Architectures: amd64 arm64

--- a/packaging/repos/focal/xpra-beta.sources
+++ b/packaging/repos/focal/xpra-beta.sources
@@ -3,3 +3,4 @@ URIs: https://xpra.org/beta
 Suites: focal
 Components: main
 Signed-By: /usr/share/keyrings/xpra.asc
+Architectures: amd64 arm64

--- a/packaging/repos/focal/xpra.sources
+++ b/packaging/repos/focal/xpra.sources
@@ -3,3 +3,4 @@ URIs: https://xpra.org
 Suites: focal
 Components: main
 Signed-By: /usr/share/keyrings/xpra.asc
+Architectures: amd64 arm64

--- a/packaging/repos/jammy/xpra-beta.sources
+++ b/packaging/repos/jammy/xpra-beta.sources
@@ -3,3 +3,4 @@ URIs: https://xpra.org/beta
 Suites: jammy
 Components: main
 Signed-By: /usr/share/keyrings/xpra.asc
+Architectures: amd64 arm64

--- a/packaging/repos/jammy/xpra.sources
+++ b/packaging/repos/jammy/xpra.sources
@@ -3,3 +3,4 @@ URIs: https://xpra.org
 Suites: jammy
 Components: main
 Signed-By: /usr/share/keyrings/xpra.asc
+Architectures: amd64 arm64

--- a/packaging/repos/kinetic/xpra-beta.sources
+++ b/packaging/repos/kinetic/xpra-beta.sources
@@ -3,3 +3,4 @@ URIs: https://xpra.org/beta
 Suites: kinetic
 Components: main
 Signed-By: /usr/share/keyrings/xpra.asc
+Architectures: amd64 arm64

--- a/packaging/repos/kinetic/xpra.sources
+++ b/packaging/repos/kinetic/xpra.sources
@@ -3,3 +3,4 @@ URIs: https://xpra.org
 Suites: kinetic
 Components: main
 Signed-By: /usr/share/keyrings/xpra.asc
+Architectures: amd64 arm64

--- a/packaging/repos/lunar/xpra-beta.sources
+++ b/packaging/repos/lunar/xpra-beta.sources
@@ -3,3 +3,4 @@ URIs: https://xpra.org/beta
 Suites: lunar
 Components: main
 Signed-By: /usr/share/keyrings/xpra.asc
+Architectures: amd64 arm64

--- a/packaging/repos/lunar/xpra.sources
+++ b/packaging/repos/lunar/xpra.sources
@@ -3,3 +3,4 @@ URIs: https://xpra.org
 Suites: lunar
 Components: main
 Signed-By: /usr/share/keyrings/xpra.asc
+Architectures: amd64 arm64

--- a/packaging/repos/sid/xpra-beta.sources
+++ b/packaging/repos/sid/xpra-beta.sources
@@ -3,3 +3,4 @@ URIs: https://xpra.org/beta
 Suites: sid
 Components: main
 Signed-By: /usr/share/keyrings/xpra.asc
+Architectures: amd64 arm64

--- a/packaging/repos/sid/xpra.sources
+++ b/packaging/repos/sid/xpra.sources
@@ -3,3 +3,4 @@ URIs: https://xpra.org
 Suites: sid
 Components: main
 Signed-By: /usr/share/keyrings/xpra.asc
+Architectures: amd64 arm64

--- a/packaging/repos/stretch/xpra-beta.sources
+++ b/packaging/repos/stretch/xpra-beta.sources
@@ -3,3 +3,4 @@ URIs: https://xpra.org/beta
 Suites: stretch
 Components: main
 Signed-By: /usr/share/keyrings/xpra.asc
+Architectures: amd64 arm64

--- a/packaging/repos/stretch/xpra.sources
+++ b/packaging/repos/stretch/xpra.sources
@@ -3,3 +3,4 @@ URIs: https://xpra.org
 Suites: stretch
 Components: main
 Signed-By: /usr/share/keyrings/xpra.asc
+Architectures: amd64 arm64

--- a/packaging/repos/xenial/xpra-beta.sources
+++ b/packaging/repos/xenial/xpra-beta.sources
@@ -3,3 +3,4 @@ URIs: https://xpra.org/beta
 Suites: xenial
 Components: main
 Signed-By: /usr/share/keyrings/xpra.asc
+Architectures: amd64 arm64

--- a/packaging/repos/xenial/xpra.sources
+++ b/packaging/repos/xenial/xpra.sources
@@ -3,3 +3,4 @@ URIs: https://xpra.org
 Suites: xenial
 Components: main
 Signed-By: /usr/share/keyrings/xpra.asc
+Architectures: amd64 arm64


### PR DESCRIPTION
On multi-arch systems (e.g. i386<->amd64) without specification of supported architectures "apt update" warns about missing packages
(e.g. "Skipping acquire of configured file 'main/binary-i386/Packages' as repository 'https://xpra.org jammy InRelease' doesn't support architecture 'i386'")