### PR TITLE
Make pulseaudio real-time and high-priority scheduling modes configurable

### DIFF
--- a/fs/etc/xpra/conf.d/60_server.conf.in
+++ b/fs/etc/xpra/conf.d/60_server.conf.in
@@ -90,7 +90,10 @@ start-new-commands = yes
 pulseaudio = %(pulseaudio)s
 
 # pulseaudio server start command:
-pulseaudio-command = %(pulseaudio_command)s
+#pulseaudio-command = %(pulseaudio_command)s
+# Note: only uncomment the above setting if you want to adjust the
+# pulseaudio command string, so the actual default value can depend on
+# the XPRA_PULSEAUDIO_* environment variables.
 
 # commands used to configure the pulseaudio server:
 # pactl set-source-volume SomeSource 20%%

--- a/xpra/scripts/config.py
+++ b/xpra/scripts/config.py
@@ -881,6 +881,12 @@ def get_default_pulseaudio_command() -> List[str]:
     MEMFD = envbool("XPRA_PULSEAUDIO_MEMFD", False)
     if not MEMFD:
         cmd.append("--enable-memfd=no")
+    REALTIME = envbool("XPRA_PULSEAUDIO_REALTIME", True)
+    if not REALTIME:
+        cmd.append("--realtime=no")
+    HIGH_PRIORITY = envbool("XPRA_PULSEAUDIO_HIGH_PRIORITY", True)
+    if not HIGH_PRIORITY:
+        cmd.append("--high-priority=no")
     return cmd
 
 


### PR DESCRIPTION
The pulseaudio tries to use real-time scheduling as the first option and increases its scheduling priority by decreasing its nice level as the second option in order to make sure that it always gets enough CPU time for refillment of the playback buffers. However, these two options require extra privileges in Linux to call the `setrlimit(RLIMIT_RTPRIO, rlim)` and `setrlimit(RLIMIT_NICE, rlim)` respectively which may be unavailable for normal users. For users which cannot call these rlimits, the pulseaudio will try for a while and so does not start quickly. In a testbed, it takes more than a minute to start up after printing these errors:

```
I: [pulseaudio] main.c: setrlimit(RLIMIT_NICE, (31, 31)) failed: Operation not permitted
I: [pulseaudio] main.c: setrlimit(RLIMIT_RTPRIO, (9, 9)) failed: Operation not permitted
```

Disabling these two features makes pulseaudio to start up with no noticable delay. This pull request introduces two environment variables, `XPRA_PULSEAUDIO_REALTIME` and `XPRA_PULSEAUDIO_HIGH_PRIORITY`, in order to selectively disable/enable them. Both settings default to `True`, keeping them enabled like now, so there will be no visible changes by default.

This pull request also fixes a packaging issue. By default, the `pulseaudio-command` setting is filled based on the `fs/etc/xpra/conf.d/60_server.conf.in` template. This configuration file overrides the value which is computed by the `get_default_pulseaudio_command()`. Therefore, the `XPRA_PULSEAUDIO_MEMFD` environment variable which was used to selectively pass `--enable-memfd=no` option to pulseaudio will have no effect. Now, the `pulseaudio-command` setting is filled as a commented line in that config file, so environment variables are kept functional while users may disable them by uncommenting that setting too.