### PR TITLE
#3937 make `packet` mutable for reprocessing

### DIFF
--- a/xpra/net/protocol/socket_handler.py
+++ b/xpra/net/protocol/socket_handler.py
@@ -1116,7 +1116,7 @@ class SocketProtocol:
                 self.input_packetcount += 1
                 self.receive_pending = bool(protocol_flags & FLAGS_FLUSH)
                 log("processing packet %s", bytestostr(packet_type))
-                self._process_packet_cb(self, tuple(packet))
+                self._process_packet_cb(self, packet)
                 del packet
 
     def do_flush_then_close(self, encoder:Optional[Callable]=None,


### PR DESCRIPTION
`_packet_recompress` in `xpra/server/proxy/proxy_instance.py` modifies the `packet`. So make `packet` mutable for reprocessing.