### PR TITLE
Moved deletion of x,y to where those variables live

### DIFF
--- a/xpra/scaling_parser.py
+++ b/xpra/scaling_parser.py
@@ -62,6 +62,7 @@ def parse_scaling(desktop_scaling, root_w, root_h, min_scaling=MIN_SCALING, max_
                         sy = float(scaleparts[1])
                     limits.append((x, y, sx, sy))
                     log("parsed desktop-scaling auto limits: %s", limits)
+                    del x, y
                 except Exception as e:
                     log.warn("Warning: failed to parse limit string '%s':", l)
                     log.warn(" %s", e)
@@ -77,7 +78,6 @@ def parse_scaling(desktop_scaling, root_w, root_h, min_scaling=MIN_SCALING, max_
                 break
         log("matched=%s : %sx%s with limits %s: %sx%s", matched, root_w, root_h, limits, sx, sy)
         return sx,sy
-    del x, y
     def parse_item(v) -> float:
         div = 1
         try:


### PR DESCRIPTION
This solves the following error:
```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/xpra/scripts/main.py", line 121, in main
    return run_mode(script_file, cmdline, err, options, args, mode, defaults)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/xpra/scripts/main.py", line 447, in run_mode
    return do_run_mode(script_file, cmdline, error_cb, options, args, mode, defaults)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/xpra/scripts/main.py", line 521, in do_run_mode
    return run_client(script_file, cmdline, error_cb, options, args, mode)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/xpra/scripts/main.py", line 1290, in run_client
    app = get_client_app(cmdline, error_cb, opts, extra_args, mode)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/xpra/scripts/main.py", line 1454, in get_client_app
    app = get_client_gui_app(error_cb, opts, request_mode, extra_args, mode)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/xpra/scripts/main.py", line 1494, in get_client_gui_app
    app.init(opts)
  File "/usr/lib/python3/dist-packages/xpra/client/gtk3/gtk_client_base.py", line 135, in init
    UIXpraClient.init(self, opts)
  File "/usr/lib/python3/dist-packages/xpra/client/gui/ui_client_base.py", line 183, in init
    c.init(self, opts)
  File "/usr/lib/python3/dist-packages/xpra/client/mixins/display.py", line 76, in init
    self.parse_scaling(opts.desktop_scaling)
  File "/usr/lib/python3/dist-packages/xpra/client/mixins/display.py", line 80, in parse_scaling
    self.initial_scaling = parse_scaling(desktop_scaling, root_w, root_h, MIN_SCALING, MAX_SCALING)
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/xpra/scaling_parser.py", line 81, in parse_scaling
    del x, y
        ^
UnboundLocalError: cannot access local variable 'x' where it is not associated with a value
```

Please note that python is not my primary coding language and I spent all of five minutes on this. Perhaps there was a reason these variables were cleaned up later? Maybe deleting `sx` and `sy` was the intention? All I can say is that in modifying my (fully updated and freshly rebooted) Debian Testing system's `/usr/lib/python3/dist-packages/xpra/scaling_parser.py` from xpra 5.0-r33872-1, it solved issue. I am running python 3.11.4 if that matters.