### PR TITLE
Support microphone for Chromium, improve audio source detection, and fix pactl output parsing

### DIFF
--- a/xpra/audio/pulseaudio/pactl_impl.py
+++ b/xpra/audio/pulseaudio/pactl_impl.py
@@ -7,7 +7,7 @@
 import sys
 import hashlib
 import os.path
-from typing import Any
+from typing import Any, Optional
 
 from xpra.audio.pulseaudio.common_util import get_pulse_server_x11_property, get_pulse_id_x11_property
 from xpra.util import print_nested_dict
@@ -137,33 +137,40 @@ def get_pa_device_options(monitors=False, input_or_output=None, ignored_devices=
 
 def do_get_pa_device_options(pactl_list_output, monitors=False, input_or_output=None,
                              ignored_devices=("bell-window-system",)):
-    device_class = ""
-    device_description = ""
-    name = ""
+    def are_properties_acceptable(name: Optional[str], device_class: Optional[str]) -> bool:
+        if name is None or device_class is None:
+            return False
+        if name in ignored_devices:
+            return False
+        #Verify against monitor flag if set:
+        if monitors is not None:
+            is_monitor = device_class == '"monitor"'
+            if is_monitor != monitors:
+                return False
+        #Verify against input flag (if set):
+        if input_or_output is not None:
+            is_input = name.lower().find("input") >= 0
+            if is_input is True and input_or_output is False:
+                return False
+            is_output = name.lower().find("output") >= 0
+            if is_output is True and input_or_output is True:
+                return False
+        return True
+
+    name : Optional[str] = None
+    device_class : Optional[str] = None
+    device_description : Optional[str] = None
     devices : dict[str,str] = {}
     for line in bytestostr(pactl_list_output).splitlines():
         if not line.startswith(" ") and not line.startswith("\t"):        #clear vars when we encounter a new section
-            if name and device_class:
-                if name in ignored_devices:
-                    continue
-                #Verify against monitor flag if set:
-                if monitors is not None:
-                    is_monitor = device_class=='"monitor"'
-                    if is_monitor!=monitors:
-                        continue
-                #Verify against input flag (if set):
-                if input_or_output is not None:
-                    is_input = name.lower().find("input")>=0
-                    if is_input is True and input_or_output is False:
-                        continue
-                    is_output = name.lower().find("output")>=0
-                    if is_output is True and input_or_output is True:
-                        continue
+            if are_properties_acceptable(name, device_class):
+                assert type(name) is str
                 if not device_description:
                     device_description = name
                 devices[name] = device_description
             name = None
             device_class = None
+            device_description = None
         line = line.strip()
         if line.startswith("Name: "):
             name = line[len("Name: "):]

--- a/xpra/client/mixins/audio.py
+++ b/xpra/client/mixins/audio.py
@@ -140,7 +140,7 @@ class AudioClient(StubClientMixin):
         if not self.microphone_codecs:
             self.microphone_allowed = False
         self.speaker_enabled = self.speaker_allowed and audio_option(opts.speaker)=="on"
-        self.microphone_enabled = self.microphone_allowed and opts.microphone.lower()=="on"
+        self.microphone_enabled = self.microphone_allowed and audio_option(mic[0])=="on"
         log("speaker: codecs=%s, allowed=%s, enabled=%s", encoders, self.speaker_allowed, csv(self.speaker_codecs))
         log("microphone: codecs=%s, allowed=%s, enabled=%s, default device=%s",
             decoders, self.microphone_allowed, csv(self.microphone_codecs), self.microphone_device)

--- a/xpra/platform/features.py
+++ b/xpra/platform/features.py
@@ -38,7 +38,7 @@ DEFAULT_ENV : tuple[str, ...] = ()
 DEFAULT_SSH_COMMAND : str = "ssh -x"
 DEFAULT_PULSEAUDIO_CONFIGURE_COMMANDS : tuple[tuple[str, str, str], ...] = (
     ("pactl", "set-default-sink", "Xpra-Speaker"),
-    ("pactl", "set-default-source", "Xpra-Microphone.monitor"),
+    ("pactl", "set-default-source", "Xpra-Mic-Source"),
     )
 
 SOCKET_OPTIONS : tuple[str, ...] = (

--- a/xpra/scripts/config.py
+++ b/xpra/scripts/config.py
@@ -861,15 +861,31 @@ def get_default_systemd_run() -> str:
 def get_default_pulseaudio_command() -> list[str]:
     if WIN32 or OSX:
         return []
+
+    def description(desc):
+        return f"device.description=\"{desc}\""
+
+    def load_opt(name, **kwargs):
+        args = " ".join([f"--load={name}"] + [f"{n}={v}" for n, v in kwargs.items()])
+        return f"'{args}'"
+
     cmd = [
         "pulseaudio", "--start", "-n", "--daemonize=false", "--system=false",
         "--exit-idle-time=-1", "--load=module-suspend-on-idle",
-        "'--load=module-null-sink sink_name=\"Xpra-Speaker\" sink_properties=device.description=\"Xpra\\ Speaker\"'",
-        "'--load=module-null-sink sink_name=\"Xpra-Microphone\" sink_properties=device.description=\"Xpra\\ Microphone\"'",
-        "'--load=module-remap-source source_name=\"Xpra-Mic-Source\" source_properties=device.description=\"Xpra\\ Mic\\ Source\" master=\"Xpra-Microphone.monitor\" channels=1'",
-        "'--load=module-native-protocol-unix socket=$XPRA_PULSE_SERVER'",
-        "--load=module-dbus-protocol",
-        "--load=module-x11-publish",
+        load_opt("module-null-sink",
+                 sink_name="Xpra-Speaker",
+                 sink_properties=description("Xpra\\ Speaker")),
+        load_opt("module-null-sink",
+                 sink_name="Xpra-Microphone",
+                 sink_properties=description("Xpra\\ Microphone")),
+        load_opt("module-remap-source",
+                 source_name="Xpra-Mic-Source",
+                 source_properties=description("Xpra\\ Mic\\ Source"),
+                 master="Xpra-Microphone.monitor",
+                 channels=1),
+        load_opt("module-native-protocol-unix", socket="$XPRA_PULSE_SERVER"),
+        load_opt("module-dbus-protocol"),
+        load_opt("module-x11-publish"),
         "--log-level=2", "--log-target=stderr",
         ]
     from xpra.util import envbool

--- a/xpra/scripts/config.py
+++ b/xpra/scripts/config.py
@@ -866,6 +866,7 @@ def get_default_pulseaudio_command() -> list[str]:
         "--exit-idle-time=-1", "--load=module-suspend-on-idle",
         "'--load=module-null-sink sink_name=\"Xpra-Speaker\" sink_properties=device.description=\"Xpra\\ Speaker\"'",
         "'--load=module-null-sink sink_name=\"Xpra-Microphone\" sink_properties=device.description=\"Xpra\\ Microphone\"'",
+        "'--load=module-remap-source source_name=\"Xpra-Mic-Source\" source_properties=device.description=\"Xpra\\ Mic\\ Source\" master=\"Xpra-Microphone.monitor\" channels=1'",
         "'--load=module-native-protocol-unix socket=$XPRA_PULSE_SERVER'",
         "--load=module-dbus-protocol",
         "--load=module-x11-publish",


### PR DESCRIPTION
This pull request addresses one server-side and three client-side issues.

In the server side, "Xpra Speaker" and "Xpra Microphone" are created as two sink devices, so client programs may write into the speaker while the xpra server reads from the "Monitor of Xpra Speaker" device and transmit them to the client side to be played. Similarly, xpra server writes into the "Xpra Microphone" and expects the programs to read their audio input stream from the "Monitor of Xpra Microphone" device.
This setup works for Mozilla Firefox flawlessly.
However, Chromium refuses to read from a monitor device and reports that there is no connected microphone. This issue is resolved by creating a remapped source device which reads from the "Monitor of Xpra Microphone" and provides it for readers as
a non-monitor source device.

In the client code,
the output of `pactl list` command is parsed line by line, looking for non-indented lines as text-block beginners, in order to find out about the input/source and output/sink devices. The following indented lines in each text-block provide attributes such as name and description for each input/output device. When a new text block is observed, the previous block (which its attributes should have been read so far) will be processed, variables which denote those attributes are reset, and then the next input/output device line is checked in order to accumulate its attributes.
The issue is that whenever a non-interesting device is detected, its processing is stopped with a `continue` which bypasses the initialization of the attribute variables. This allows a variable to keep its value during the processing of the next block attributes and if the next block is not going to provide any value for that attribute, the old value from the previous block will be used instead, causing false matches.

Second client-side issue is an improvement in detection of some virtual devices which do not report the `device.class="monitor"` attribute, even though they are monitor devices. These devices can be detected by looking for the `Monitor of Sink` line which reports the corresponding sink device or `n/a` if there is no such a sink device. This pull request, in the special scenario that `device.class` is missing, checks for presence of the `Monitor of Sink` line and only ignores a device if its `is_monitor` state may not be detected with both methods.

Third and last, the computation of the `microphone_enabled` was correct for a single value as it was compared with the `"on"` constant. However, if a device was specified in the same option (i.e., "on:device"), it failed to enable the microphone by default (although the "device" part was parsed out correctly and enabling the microphone via a menu could work as expected).