### PR TITLE
Reverse the webcam aspect ratio in webcam-start message

### DIFF
--- a/xpra/client/mixins/webcam.py
+++ b/xpra/client/mixins/webcam.py
@@ -160,7 +160,7 @@ class WebcamForwarder(StubClientMixin):
             assert ret, "no device or permission"
             assert frame is not None, "no data"
             assert frame.ndim==3, "unexpected  number of dimensions: %s" % frame.ndim
-            w, h, Bpp = frame.shape
+            h, w, Bpp = frame.shape
             assert Bpp==3, "unexpected number of bytes per pixel: %s" % Bpp
             assert frame.size==w*h*Bpp
             self.webcam_device_no = device


### PR DESCRIPTION
The OpenCV library, expects to retrieve `size = (width, height)` tuple, for example, when resizing a frame. However, it reports `(height, width)` when reporting the frame size as a NumPy array. Here is the [relevant quotation](https://learnopencv.com/reading-and-writing-videos-using-opencv/):

    If you are using the NumPy shape method to retrieve frame size,
    remember to reverse the output as OpenCV will return height x width x channels.

This reversed aspect ratio reporting subtlety was correctly handled in the `webcam-frame` messages, however, it was missed in
the `webcam-start` message.