### PR TITLE
qrcode: gracefully fail during menu creation

### DIFF
--- a/xpra/client/gtk3/menu_helper.py
+++ b/xpra/client/gtk3/menu_helper.py
@@ -452,16 +452,16 @@ class MenuHelper:
 
 
     def make_qrmenuitem(self) -> Gtk.ImageMenuItem:
-        from xpra.net.qrcode.gtk_qr import show_qr
-        def show(*_args):
-            uri = self.client.display_desc.get("display_name")
-            show_qr(uri)
-        qr_menuitem = self.menuitem("Show QR connection string", "qr.png", None, show)
         try:
             from xpra.net.qrcode.qrencode import encode_image
         except ImportError as e:
             log(f"no qrcode support {e}")
             return None
+        from xpra.net.qrcode.gtk_qr import show_qr
+        def show(*_args):
+            uri = self.client.display_desc.get("display_name")
+            show_qr(uri)
+        qr_menuitem = self.menuitem("Show QR connection string", "qr.png", None, show)
         log("make_qrmenuitem() qrencode.encode_image=%s", encode_image)
         if encode_image:
             def with_connection(*_args):


### PR DESCRIPTION
If xpra is built without `qrencode.h` available, `xpra/net/qrcode` is not copied over because `qrencode_ENABLED` is set to false (line 2266 of `setup.py`).

In the modified file, `from xpra.net.qrcode.gtk_qr import show_qr` will then fail, causing `xpra/client/gtk3/menu_helper.py::MenuHelper::build` to fail with `Error: failed to setup menu`.  The symptom is a missing tray icon, and while the best fix is may be to build with qrencode available, some people may not want that enabled.

The minimal fix below moves the failsafe logic before the first import, which is presumably what was intended anyway.