### PR TITLE
Debian packaging fixes for sid and trixie (master branch)

### DIFF
--- a/packaging/debian/xpra/control
+++ b/packaging/debian/xpra/control
@@ -279,8 +279,8 @@ Depends: xpra-codecs (= ${binary:Version})
 #lunar:              ,libavif15
 #mantic:              ,libavif15
 #bookworm:              ,libavif15
-#trixie:              ,libavif15
-#sid:              ,libavif15
+#trixie:              ,libavif16
+#sid:              ,libavif16
 Recommends:
         ,gstreamer-plugins-ugly
         ,gstreamer1.0-vaapi

--- a/packaging/debian/xpra/rules
+++ b/packaging/debian/xpra/rules
@@ -30,8 +30,8 @@ override_dh_installchangelogs:
 
 override_dh_shlibdeps:
 	dh_shlibdeps -Xcodecs/ -Xx11 -Xgdk -Xgtk -Xbrotli/ -Xqrcode/ -Xproc_ -Xsd_listen
-	dh_shlibdeps -Xnvidia/ -Xavif/ -Xffmpeg/ -Xgstreamer/ -Xx264/ -Xx11 -Xgdk -Xgtk -Xbrotli/ -Xqrcode/ -Xproc_ -Xsd_listen -- -pcodecs
-	dh_shlibdeps -Xnvidia/ -Xcsc_cython/ -Xdrm/ -Xevdi/ -Xjpeg/ -Xlibyuv/ -Xspng/ -Xv4l2/ -Xvpx/ -Xwebp/ -Xx11 -Xgdk -Xgtk -Xbrotli/ -Xqrcode/ -Xproc_ -Xsd_listen -- -pcodecsextras
+	dh_shlibdeps -Xnvidia/ -Xffmpeg/ -Xgstreamer/ -Xx264/ -Xx11 -Xgdk -Xgtk -Xbrotli/ -Xqrcode/ -Xproc_ -Xsd_listen -- -pcodecs
+	dh_shlibdeps -Xnvidia/ -Xavif/ -Xcsc_cython/ -Xdrm/ -Xevdi/ -Xjpeg/ -Xlibyuv/ -Xspng/ -Xv4l2/ -Xvpx/ -Xwebp/ -Xx11 -Xgdk -Xgtk -Xbrotli/ -Xqrcode/ -Xproc_ -Xsd_listen -- -pcodecsextras
 	dh_shlibdeps -Xcodecs/ -Xgdk -Xgtk -Xbrotli/ -Xqrcode/ -Xproc_ -Xsd_listen -- -px11
 	dh_shlibdeps -Xcodecs/ -Xx11 -Xgdk -Xgtk -Xqrcode/ -Xproc_ -Xsd_listen -- -pbrotli
 	dh_shlibdeps -Xcodecs/ -Xx11 -Xgdk -Xgtk -Xbrotli/ -Xproc_ -Xsd_listen -- -pqrcode


### PR DESCRIPTION
As of this moment, the xpra-codecs package (and the xpra package itself by extension) is effectively uninstallable on up-to-date trixie/testing and sid/unstable Debian systems due to a dependency on libavif15. As of 2023-10-07 and 2023-10-12 for sid and trixie respectively, Debian's libavif binary package has been renamed libavif16 from the previous libavif15, and libavif15 is no longer available in sid or trixie. I've updated the control file accordingly.

Also, although commit f1787a07b1fe4ebb6b9b2b57309a36396c39a2cb aimed to move the avif dependency to the codecs-extras package, it was effectively moved _from_ the codecs-extras package _to_ the codecs package in the override_dh_shlibdeps rule, which means even with the libavif16 update making the package installable, the codecs package still pulls in avif's huge dependency list. I assume this was a mistake so I've reverted that one change and included it in this PR as well.