### PR TITLE
Debian packaging fix for sid and trixie (v5.x branch)

### DIFF
--- a/packaging/debian/xpra/control
+++ b/packaging/debian/xpra/control
@@ -282,8 +282,8 @@ Depends: xpra-common (= ${binary:Version})
 #lunar:              ,libavif15
 #mantic:              ,libavif15
 #bookworm:              ,libavif15
-#trixie:              ,libavif15
-#sid:              ,libavif15
+#trixie:              ,libavif16
+#sid:              ,libavif16
 #jammy:              ,libyuv0
 #lunar:              ,libyuv0
 #mantic:              ,libyuv0


### PR DESCRIPTION
As of this moment, the xpra-codecs package (and the xpra package itself by extension) is effectively uninstallable on up-to-date trixie/testing and sid/unstable Debian systems due to a dependency on libavif15. As of 2023-10-07 and 2023-10-12 for sid and trixie respectively, Debian's libavif binary package has been renamed libavif16 from the previous libavif15, and libavif15 is no longer available in sid or trixie. I've updated the control file accordingly.

(Description copied from #4071 as that PR fixes the same issue in the master branch.)