### PR TITLE
Fix calc_constrained_size vertical calculation with maximum_size hint

### DIFF
--- a/xpra/x11/models/window.py
+++ b/xpra/x11/models/window.py
@@ -101,7 +101,7 @@ def calc_constrained_size(width : int, height : int, hints):
     if max_width>0:
         width = min(max_width, width)
     if max_height>0:
-        height = max(min_height, height)
+        height = min(max_height, height)
 
     base_width, base_height = getintpair("base-size", 0, 0)
     increment_x, increment_y = getintpair("increment", 0, 0)


### PR DESCRIPTION
Fixes incorrect results observed from calc_constrained_size failing to constrain in the vertical axis when a maximum_size hint was present. 