### PR TITLE
Maximized state is lost when other window properties update

### DIFF
--- a/xpra/client/gtk3/window_base.py
+++ b/xpra/client/gtk3/window_base.py
@@ -1096,6 +1096,12 @@ class GTKClientWindowBase(ClientWindowBase, Gtk.Window):
                 self.cancel_send_iconifiy_timer()
                 self._frozen = False
                 self.process_map_event()
+
+        # Always send maximized if some other update is performed. It is a
+        # per-client setting that is mirrored as part of every update.
+        if server_updates and 'maximized' not in server_updates:
+            server_updates['maximized'] = self._maximized
+
         statelog("window_state_updated(..) state updates: %s, actual updates: %s, server updates: %s",
                  state_updates, actual_updates, server_updates)
         if "maximized" in state_updates:


### PR DESCRIPTION
# Problem

The maximized state gets lost when some other property of the window (like its focus state) is changed.

For example:

1. Environments:
    - Fedora server (running 6.0-r35018)
    - Windows 11 client (running 6.0-r34988)
2. `xpra start --bind-tcp=0.0.0.0:1995 --daemon=no :1` (this shouldn't be protocol specific though)
3. `DISPLAY=:1 xterm`
4. Connect from Windows. This displays the xterm at its default size.
5. Maximize the xterm using window snapping or the title bar button.
6. Switch focus to some other application. I've tried using another application on a different monitor, though this should work with Alt+Tab too.

# Expected Result

The xterm loses its focus but stays maximized.

# Actual Result

The xterm reverts to its initial size.

# Analysis

This seems to be a conflict between how the server handles `maximized` and how the client does. `xpra.server.window.compress` never carries over the value from previous window config events,
unlike other property types:

```
    def do_set_client_properties(self, properties: typedict) -> None:
        self.maximized = properties.boolget("maximized", False)
        self.client_render_size = properties.intpair("encoding.render-size")
        self.client_bit_depth = properties.intget("bit-depth", self.client_bit_depth)
        ...
```

The client only sends the value if it's changed since the last update. So if you maximize the window
and then do something else, `maximized` gets reset and the client unmaximizes the window once
it's notified of the property change.

The fix here just makes sure that every client property change request includes the `maximized` flag,
so the server never has a chance to reset the value.