### PR TITLE
fix NVENC in v5.x 

### DIFF
--- a/xpra/server/window/window_video_source.py
+++ b/xpra/server/window/window_video_source.py
@@ -1922,7 +1922,7 @@ class WindowVideoSource(WindowSource):
         #tweaks for "real" video:
         opts = {}
         if self.cuda_device_context:
-            options["cuda-device-context"] = self.cuda_device_context
+            opts["cuda-device-context"] = self.cuda_device_context
         if not self._fixed_quality and not self._fixed_speed and self._fixed_min_quality<50:
             #only allow bandwidth to drive video encoders
             #when we don't have strict quality or speed requirements:


### PR DESCRIPTION
This has the effect of breaking the NVENC path due to the resulting NameError.