### PR TITLE
Match NamedPipeConnection on Windows 

### DIFF
--- a/xpra/platform/win32/namedpipes/connection.py
+++ b/xpra/platform/win32/namedpipes/connection.py
@@ -123,7 +123,7 @@ class NamedPipeConnection(Connection):
         log("pipe_read: %i bytes", len(data or ""))          #, binascii.hexlify(s))
         return data
 
-    def write(self, buf):
+    def write(self, buf, packet_type=None):
         return self._write(self._pipe_write, buf)
 
     def _pipe_write(self, buf):


### PR DESCRIPTION
The NamedPipeConnection.write has been changed to 3 arguments, windows OS client will throw the following errors.
```
2024-03-25 18:57:08,615 Error: write on \\.\pipe\Xpra\59704 failed: <class 'TypeError'>
Traceback (most recent call last):
  File "E:/xpra/xpra/net/protocol/socket_handler.py", line 670, in _io_thread_loop
  File "E:/xpra/xpra/net/protocol/socket_handler.py", line 697, in _write
  File "E:/xpra/xpra/net/protocol/socket_handler.py", line 720, in write_items
  File "E:/xpra/xpra/net/protocol/socket_handler.py", line 744, in write_buffers
  File "E:/xpra/xpra/net/protocol/socket_handler.py", line 755, in con_write
TypeError: NamedPipeConnection.write() takes 2 positional arguments but 3 were given
```

I think we just follow the change and leave the packet_type as no use.
First time submitting a PR to such a big project, I am sorry if any inconvenience.