### PR TITLE
jhbuild: update instructions for 'local modulesets'.

### DIFF
--- a/docs/Build/MacOS.md
+++ b/docs/Build/MacOS.md
@@ -8,8 +8,8 @@ Install [XCode](https://developer.apple.com/xcode/) and its command line tools.
 
 Download the latest version of the [gtk-osx](https://wiki.gnome.org/Projects/GTK/OSX/Building) setup script and run it:
 ```shell
-curl -o ~/gtk-osx-setup.sh \
-     https://raw.githubusercontent.com/Xpra-org/gtk-osx-build/master/gtk-osx-setup.sh
+git clone https://github.com/Xpra-org/gtk-osx-build
+cd gtk-osx-build
 sh gtk-osx-setup.sh
 ```
 This will have installed `jhbuild` in `~/.new_local/bin`, so let's add this to our `$PATH`:
@@ -21,8 +21,8 @@ export PATH=$PATH:~/.new_local/bin/
   <summary>Configure `jhbuild` to use our modules</summary>
 
 ```shell
-curl -o ~/.config/jhbuildrc-custom \
-     https://raw.githubusercontent.com/Xpra-org/gtk-osx-build/master/jhbuildrc-custom
+ln -sf $(pwd)/gtk-osx-build/jhbuildrc-gtk-osx ~/.config/jhbuildrc
+ln -sf $(pwd)/gtk-osx-build/jhbuildrc-custom ~/.config/jhbuildrc-custom
 ```
 </details>
 


### PR DESCRIPTION
Became broken in
https://github.com/Xpra-org/gtk-osx-build/commit/c781ec5b8c993315eb126ba7d25f6e3fcbf63962.

Reference for jhbuild configuration steps: https://github.com/Xpra-org/gtk-osx-build/blob/master/.github/workflows/macos.yml

Should fix https://github.com/Xpra-org/xpra/issues/4203