### PR TITLE
respect python PATH

### DIFF
--- a/fs/bin/run_scaled
+++ b/fs/bin/run_scaled
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # pylint: disable=import-outside-toplevel
 

--- a/fs/bin/xpra
+++ b/fs/bin/xpra
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 

--- a/fs/bin/xpra_launcher
+++ b/fs/bin/xpra_launcher
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import sys

--- a/fs/lib/cups/backend/xpraforwarder
+++ b/fs/lib/cups/backend/xpraforwarder
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 #
 # xpraforwarder - A CUPS backend written in Python.

--- a/fs/libexec/xpra/auth_dialog
+++ b/fs/libexec/xpra/auth_dialog
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import sys
 

--- a/fs/libexec/xpra/xdg-open
+++ b/fs/libexec/xpra/xdg-open
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # This file is part of Xpra.
 # Copyright (C) 2017-2020 Antoine Martin <antoine@xpra.org>
 # Xpra is released under the terms of the GNU GPL v2, or, at your option, any

--- a/fs/libexec/xpra/xpra_signal_listener
+++ b/fs/libexec/xpra/xpra_signal_listener
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 import sys


### PR DESCRIPTION
Required for when python is installed in any other location than `/usr/bin`.

Note, some extra attention is required, the 6.0 release .rpm's (at least for almalinux 8) actually contain `#!/usr/bin/python3.11`. But I was only able to find `#!/usr/bin/python3` in the source code. So I'm not exactly sure what is going on here.