### PR TITLE
remove "no test suite" from man page

### DIFF
--- a/fs/share/man/man1/xpra.1
+++ b/fs/share/man/man1/xpra.1
@@ -1780,8 +1780,6 @@ and used by \fBxpra attach\fP (see also the discussion of
 \fB\-\-remote\-xpra\fP).
 .\" --------------------------------------------------------------------
 .SH BUGS
-Xpra has no test suite.
-
 Xpra does not fully handle all aspects of the X protocol; for
 instance, fancy input features like pressure-sensitivity on tablets,
 some window manager hints, and probably other more obscure parts of the


### PR DESCRIPTION
I almost had a heart attack reading this, but it turns out that line was simply left in accidentally [in 2007](https://github.com/Xpra-org/xpra/blob/6714b113722aefddbc5b5cdee1414d9490f4a522/docs/CHANGELOG.md?plain=1#L2359).