### PR TITLE
A GNOME Shell extension for input sources management

### DIFF
--- a/fs/share/gnome-shell/extensions/input-source-manager@xpra_org/README.md
+++ b/fs/share/gnome-shell/extensions/input-source-manager@xpra_org/README.md
@@ -1,0 +1,41 @@
+# Input Source Manager (ISM) Extension for GNOME Shell
+
+The GNOME Shell has restricted D-Bus interface access to some of its
+private APIs since [v41.0](https://gitlab.gnome.org/GNOME/gnome-shell/-/commit/a628bbc4)
+including the `org.gnome.Shell.Eval` method which was used by Xpra for
+updating the client platform selected input source.
+Therefore, this extension is implemented in order to expose the listing
+and setting of input sources through a D-Bus interface.
+Two methods are exposed by the provided D-Bus interface:
+
+  1. List: provides the `.inputSources` list,
+  2. Activate: takes a numeric index which must exist in the `.inputSources`
+  and tries to activate it.
+
+## CLI Verification
+
+If the extension is installed and enabled, above methods may be tested
+from CLI using the `gdbus` program as follows:
+
+```
+# List available input sources
+gdbus call --session --dest org.gnome.Shell --object-path /org/xpra/InputSourceManager --method xpra_org.InputSourceManager.List
+# Activate the first available input source (with index 0)
+gdbus call --session --dest org.gnome.Shell --object-path /org/xpra/InputSourceManager --method xpra_org.InputSourceManager.Activate 0
+```
+
+## Enabling
+
+The `input-source-manager@xpra_org` GNOME Shell extension must be
+installed and enabled if it is desired to update the platform keyboard
+layout when the `next_keyboard_layout` is called.
+In recent GNOME versions which ship the `gnome-extensions` program, this
+extension may be enabled by running the following command.
+
+```
+/usr/bin/gnome-extensions enable input-source-manager@xpra_org
+```
+
+Alternatively, it may be enabled manually by searching for
+the `Extensions` (by pressing the `Super` key) and finding that
+extension in the filtered list.

--- a/fs/share/gnome-shell/extensions/input-source-manager@xpra_org/extension.js
+++ b/fs/share/gnome-shell/extensions/input-source-manager@xpra_org/extension.js
@@ -1,0 +1,74 @@
+/* extension.js
+ *
+ * Copyright (C) 2024 Graph Inc.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+const { Gio } = imports.gi;
+const { getInputSourceManager } = imports.ui.status.keyboard;
+
+const XMLInterface = `<node>
+  <interface name="xpra_org.InputSourceManager">
+    <method name="Activate">
+      <arg type="i" direction="in" name="index" />
+      <arg type="b" direction="out" name="success" />
+      <arg type="s" direction="out" name="error" />
+    </method>
+    <method name="List">
+      <arg type="b" direction="out" name="success" />
+      <arg type="s" direction="out" name="inputSources" />
+    </method>
+  </interface>
+</node>
+`;
+
+function init(meta) {
+    return new InputSourceManagerInterface();
+}
+
+class InputSourceManagerInterface {
+    enable() {
+        this._ism = new ISMWrapper();
+        this._dbusObj= Gio.DBusExportedObject.wrapJSObject(XMLInterface, this._ism);
+        this._dbusObj.export(Gio.DBus.session, '/org/xpra/InputSourceManager');
+    }
+
+    disable() {
+        if (this._dbusObj) {
+            this._dbusObj.unexport();
+            this._dbusObj= null;
+        }
+        this._ism = null;
+    }
+}
+
+class ISMWrapper {
+    Activate(index) {
+        const inputSources = getInputSourceManager().inputSources;
+        const len = inputSources.length
+        if (index < 0 || index >= len) {
+            return [false, `index (${index}) must be in [0, ${len})`];
+        }
+        inputSources[index].activate();
+        return [true, `input source with index ${index} is activated`];
+    }
+
+    List() {
+        const inputSources = getInputSourceManager().inputSources;
+        return [true, JSON.stringify(inputSources)];
+    }
+}

--- a/fs/share/gnome-shell/extensions/input-source-manager@xpra_org/metadata.json
+++ b/fs/share/gnome-shell/extensions/input-source-manager@xpra_org/metadata.json
@@ -1,0 +1,17 @@
+{
+  "description": "Provide D-Bus interface for listing/activating input sources",
+  "name": "Input Source Manager D-Bus interface",
+  "shell-version": [
+    "3.32",
+    "3.36",
+    "3.38",
+    "40",
+    "41",
+    "42",
+    "43",
+    "44"
+  ],
+  "url": "https://github.com/Xpra-org/xpra/",
+  "uuid": "input-source-manager@xpra_org",
+  "version": 1
+}

--- a/packaging/debian/xpra/control
+++ b/packaging/debian/xpra/control
@@ -219,13 +219,22 @@ Suggests: xpra-codecs-nvidia (= ${binary:Version})
         ,python-psutil
 # webcam support:
         ,python3-opencv
-# to make the system tray work again with gnome-shell:
-        ,gnome-shell-extension-top-icons-plus
-        ,gnome-shell-extension-appindicator
+        ,xpra-client-gnome
 # password prompts:
         ,pinentry-gnome3
 Description: tool to detach/reattach running X programs,
  this is the xpra client user interface using GTK3
+
+
+Package: xpra-client-gnome
+Architecture: any
+Depends: xpra-client-gtk3 (= ${binary:Version})
+        ,gnome-shell-extension-top-icons-plus
+        ,gnome-shell-extension-appindicator
+Description: This package installs the GNOME Shell extensions
+ that can help in restoring the system tray functionality.
+ It also includes the input-source-manager@xpra_org extension which
+ is required for querying and activating keyboard input sources.
 
 
 Package: xpra-audio

--- a/packaging/debian/xpra/xpra-client-gnome.files
+++ b/packaging/debian/xpra/xpra-client-gnome.files
@@ -1,0 +1,4 @@
+usr/share/gnome-shell/extensions/input-source-manager@xpra_org/COPYING
+usr/share/gnome-shell/extensions/input-source-manager@xpra_org/README.md
+usr/share/gnome-shell/extensions/input-source-manager@xpra_org/extension.js
+usr/share/gnome-shell/extensions/input-source-manager@xpra_org/metadata.json

--- a/packaging/rpm/xpra.spec
+++ b/packaging/rpm/xpra.spec
@@ -38,6 +38,8 @@ autoprov: no
 %define DEFAULT_BUILD_ARGS --with-Xdummy --without-Xdummy_wrapper --without-csc_cython --without-evdi --without-cuda_rebuild
 %endif
 
+%global gnome_shell_extension input-source-manager@xpra_org
+
 %{!?nthreads: %global nthreads %(nproc)}
 %{!?update_firewall: %define update_firewall 1}
 %{!?run_tests: %define run_tests 0}
@@ -343,8 +345,10 @@ Requires:			gnome-shell-extension-appindicator
 Requires(post):		gnome-shell-extension-common
 %endif
 %description -n%{package_prefix}-client-gnome
-This meta package installs the gnome shell extensions
+This package installs the GNOME Shell extensions
 that can help in restoring the system tray functionality.
+It also includes the %{gnome_shell_extension} extension which
+is required for querying and activating keyboard input sources.
 
 
 %package -n %{package_prefix}-x11
@@ -536,7 +540,10 @@ rm -rf $RPM_BUILD_ROOT
 #meta package
 
 %files -n %{package_prefix}-client-gnome
-#meta package without any files
+%{_datadir}/gnome-shell/extensions/%{gnome_shell_extension}/COPYING
+%{_datadir}/gnome-shell/extensions/%{gnome_shell_extension}/README.md
+%{_datadir}/gnome-shell/extensions/%{gnome_shell_extension}/extension.js
+%{_datadir}/gnome-shell/extensions/%{gnome_shell_extension}/metadata.json
 
 %files -n xpra-filesystem
 %defattr(-,root,root)
@@ -839,8 +846,10 @@ for uid in `ls /run/user/`; do
     if [ -S "${BUS}" ]; then
 %if 0%{?el8}
 sudo -i -u "#$uid" DBUS_SESSION_BUS_ADDRESS="unix:path=$BUS" gnome-shell-extension-tool -e TopIcons@phocean.net  &>/dev/null || :
+sudo -i -u "#$uid" DBUS_SESSION_BUS_ADDRESS="unix:path=$BUS" gnome-shell-extension-tool -e %{gnome_shell_extension}  &>/dev/null || :
 %else
 sudo -i -u "#$uid" DBUS_SESSION_BUS_ADDRESS="unix:path=$BUS" gnome-extensions enable appindicatorsupport@rgcjonas.gmail.com  &>/dev/null || :
+sudo -i -u "#$uid" DBUS_SESSION_BUS_ADDRESS="unix:path=$BUS" gnome-extensions enable %{gnome_shell_extension}  &>/dev/null || :
 %endif
     fi
 done

--- a/setup.py
+++ b/setup.py
@@ -282,6 +282,7 @@ uinput_ENABLED = x11_ENABLED
 dbus_ENABLED = DEFAULT and (x11_ENABLED or WIN32) and not OSX
 gtk_x11_ENABLED = DEFAULT and not WIN32 and not OSX
 gtk3_ENABLED = DEFAULT and client_ENABLED
+ism_ext_ENABLED = DEFAULT and gtk3_ENABLED and data_ENABLED
 opengl_ENABLED = DEFAULT and client_ENABLED
 has_pam_headers = has_header_file("/security", isdir=True) or pkg_config_ok("--exists", "pam", "pam_misc")
 pam_ENABLED = DEFAULT and (server_ENABLED or proxy_ENABLED) and LINUX and has_pam_headers
@@ -437,6 +438,7 @@ SWITCHES += [
     "server", "client", "dbus", "x11", "xinput", "uinput", "sd_listen",
     "gtk_x11", "service",
     "gtk3", "example",
+    "ism_ext",
     "pam", "xdg_open",
     "audio", "opengl", "printing", "webcam", "notifications", "keyboard",
     "rebuild",
@@ -1573,7 +1575,7 @@ if "install" in sys.argv or "build" in sys.argv:
         # ensure it is now included in the module list
         add_modules("xpra.src_info")
 
-if POSIX and gtk3_ENABLED and data_ENABLED:
+if POSIX and ism_ext_ENABLED:
     ism_dir = "share/gnome-shell/extensions/input-source-manager@xpra_org"
     data_files.append((ism_dir, glob(f"fs/{ism_dir}/*")))
     data_files.append((ism_dir, ["COPYING"]))

--- a/setup.py
+++ b/setup.py
@@ -1573,6 +1573,10 @@ if "install" in sys.argv or "build" in sys.argv:
         # ensure it is now included in the module list
         add_modules("xpra.src_info")
 
+if POSIX and gtk3_ENABLED and data_ENABLED:
+    ism_dir = "share/gnome-shell/extensions/input-source-manager@xpra_org"
+    data_files.append((ism_dir, glob(f"fs/{ism_dir}/*")))
+    data_files.append((ism_dir, ["COPYING"]))
 
 if "clean" in sys.argv or "sdist" in sys.argv:
     clean()


### PR DESCRIPTION
Previously, we used `org.gnome.Shell.Eval` D-Bus method in order to list and activate input sources, when it was required to update the Linux platform keyboard layout. However, that method is not accessible since GNOME Shell v41.0 due to [this commit](https://gitlab.gnome.org/GNOME/gnome-shell/-/commit/a628bbc4).

This pull request installs a new GNOME Shell extension, namely `input-source-manager@xpra_org`, which exposes the `xpra_org.InputSourceManager.List` and `xpra_org.InputSourceManager.Activate` D-Bus methods and calls them instead of the internal `Eval` method.