### PR TITLE
use --ssh when reconnecting

### DIFF
--- a/xpra/scripts/config.py
+++ b/xpra/scripts/config.py
@@ -822,6 +822,7 @@ CLIENT_OPTIONS: list[str] = [
     "compressors", "packet-encoders",
     "key-shortcut",
     "env",
+    "ssh",
 ]
 
 CLIENT_ONLY_OPTIONS: list[str] = [


### PR DESCRIPTION
Reconnects did not use the `--ssh` args which can lead to using paramiko and/or missing options.

In my case it prompted for a password on reconnect even though there was a perfectly fine key just waiting to be used.

Reproduce:
- set up ssh with pubkey
- `xpra --ssh=... start`
- wait until connected
- kill ssh process to trigger reconnect (also caused by wifi problems)
- observe password prompt (not anymore with this patch)