### PR TITLE
POINTER(None) is not a valid construct.

### DIFF
--- a/xpra/platform/win32/pdfium.py
+++ b/xpra/platform/win32/pdfium.py
@@ -29,7 +29,7 @@ class FPDF_LIBRARY_CONFIG(Structure):
     _fields_ = [
         ("version", c_int),
         ("m_pUserFontPaths", POINTER(POINTER(c_char))),
-        ("m_pIsolate", POINTER(None)),
+        ("m_pIsolate", c_void_p),
         ("m_v8EmbedderSlot", c_uint),
     ]
 


### PR DESCRIPTION
sonarqube static analyzer

Change this argument; Function "POINTER" expects a different type Arguments given to functions should be of an expected type[python:S5655](https://sonarqube-xpra.vpo.nl/coding_rules?open=python%3AS5655&rule_key=python%3AS5655)

fixes #4276