### PR TITLE
Bugfix: When checking for existing user config, expand tilde to HOME

### DIFF
--- a/xpra/scripts/config.py
+++ b/xpra/scripts/config.py
@@ -473,7 +473,8 @@ def may_create_user_config(xpra_conf_filename:str = DEFAULT_XPRA_CONF_FILENAME):
     if udirs:
         has_user_conf = None
         for d in udirs:
-            if os.path.exists(d):
+            ad = os.path.expanduser(d)
+            if os.path.exists(ad):
                 has_user_conf = d
                 break
         if not has_user_conf:


### PR DESCRIPTION
Without this, os.path.exists looks for a literal directory named '~' and returns False, causing Xpra to overwrite the existing user config