### PR TITLE
Windows printing: only one page of a multipage document is printed

### DIFF
--- a/xpra/platform/win32/pdfium.py
+++ b/xpra/platform/win32/pdfium.py
@@ -16,7 +16,7 @@ from ctypes import (
 from xpra.util.str_fn import Ellipsizer, strtobytes
 from xpra.platform.win32.common import GetDeviceCaps
 from xpra.platform.win32 import win32con
-from xpra.platform.win32.ctypes_printing import GDIPrinterContext, DOCINFO, StartDocA, EndDoc, LPCSTR
+from xpra.platform.win32.ctypes_printing import GDIPrinterContext, DOCINFO, StartDocA, EndDoc, StartPage, EndPage, LPCSTR
 
 LIBPDFIUMDLL = os.environ.get("XPRA_LIBPDFIUMDLL", "pdfium.dll")
 try:
@@ -55,6 +55,8 @@ FPDF_LoadMemDocument.restype = FPDF_DOCUMENT
 FPDF_LoadMemDocument.argtypes = [c_void_p, c_int, c_void_p]
 FPDF_CloseDocument = pdfium.FPDF_CloseDocument
 FPDF_CloseDocument.argtypes = [FPDF_DOCUMENT]
+FPDF_ClosePage = pdfium.FPDF_ClosePage
+FPDF_ClosePage.argtypes = [FPDF_PAGE]
 
 FPDF_ERR_SUCCESS = 0  # No error.
 FPDF_ERR_UNKNOWN = 1  # Unknown error.
@@ -141,7 +143,10 @@ def do_print_pdf(hdc, title=b"PDF Print Test", pdf_data=None):
                     log.error("Error: FPDF_LoadPage failed for page %i, error: %s", i, get_error())
                     return -2
                 log("FPDF_LoadPage()=%s page %i loaded", page, i)
+                StartPage(hdc)
                 FPDF_RenderPage(hdc, page, x, y, w, h, rotate, flags)
+                FPDF_ClosePage(hdc)
+                EndPage(hdc)
                 log("FPDF_RenderPage page %i rendered", i)
         finally:
             EndDoc(hdc)


### PR DESCRIPTION
Bugfix: not all pages of an multipage pdf document is printed.

### Solution
Before a new page is sent to the printer, prepare the printer to accept date After rendering of a page is finished the page is closed and the printer device is notified. 

### Some links on how I came to my solution
[StartPage](https://learn.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-startpage) 
[EndPage](https://learn.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-endpage)

[FoxIt PDF SDK User Manual](http://cdn01.foxitsoftware.com/pub/foxit/manual/enu/FoxitPDF_SDK20_Guide.pdf)