### PR TITLE
Fix starting stderr_reader as a thread in exec_client.py

### DIFF
--- a/xpra/net/ssh/exec_client.py
+++ b/xpra/net/ssh/exec_client.py
@@ -198,7 +198,7 @@ def connect_to(display_desc, opts=None, debug_cb: Callable = noop, ssh_fail_cb=c
     conn.process = (child, "ssh", cmd)
     if kwargs.get("stderr") == PIPE:
 
-        start_thread(stderr_reader, "ssh-stderr-reader", daemon=True)
+        start_thread(stderr_reader, "ssh-stderr-reader", args=(child,), daemon=True)
     return conn
 
 


### PR DESCRIPTION
When an ssh program is given with "--ssh" option, its stderr may be connected through a pipe. To manage reading the stream, a separate thread is started that has child process (ssh impl) as a parameter. Starting the thread, however, does not provide the corresponding argument, leading to an exception.

This fixes the exception by providing required argument.