### PR TITLE
Fix x11 clipboard INCR protocol

### DIFF
--- a/xpra/x11/gtk/clipboard.py
+++ b/xpra/x11/gtk/clipboard.py
@@ -571,6 +571,7 @@ class ClipboardProxy(ClipboardProxyCore, GObject.GObject):
                     self.incr_data_type = ""
                     log("incremental clipboard data of size %s", self.incr_data_size)
                     self.reschedule_incr_data_timer()
+                    X11Window.XDeleteProperty(self.xid, event.atom)
                     return
                 if self.incr_data_size > 0:
                     # incremental is now in progress:
@@ -586,6 +587,7 @@ class ClipboardProxy(ClipboardProxyCore, GObject.GObject):
                         log("got incremental data: %i bytes", len(data))
                         self.incr_data_chunks.append(data)
                         self.reschedule_incr_data_timer()
+                        X11Window.XDeleteProperty(self.xid, event.atom)
                         return
                     self.cancel_incr_data_timer()
                     data = b"".join(self.incr_data_chunks)


### PR DESCRIPTION
Need to call XDeleteProperty api to receive more data from sender.
Without this, in my computer when I am trying to copy lots of data, the clipboard is failed and stops to work even with small size of data copy before restarting the service.

My setup is:
Server : Ubuntu 24.04
Client : Windows 11

Please refer to the below documents.

https://www.x.org/releases/X11R7.6/doc/xorg-docs/specs/ICCCM/icccm.html#large_data_transfers
https://www.x.org/releases/X11R7.6/doc/xorg-docs/specs/ICCCM/icccm.html#incr_properties

> Waits between each append for a PropertyNotify (state==Deleted) event that shows that the requestor has read the data. The reason for doing this is to limit the consumption of space in the server.

Deleted state can be set by calling XDeleteProperty()