### PR TITLE
Fix "--keyboard-sync" option is effective in command line.

### DIFF
--- a/xpra/client/gui/keyboard_helper.py
+++ b/xpra/client/gui/keyboard_helper.py
@@ -348,6 +348,7 @@ class KeyboardHelper:
             v = getattr(self, x)
             if v:
                 props[x] = v
+        props["sync"] = self.keyboard_sync
         return props
 
     def log_keyboard_info(self) -> None:

--- a/xpra/server/keyboard_config_base.py
+++ b/xpra/server/keyboard_config_base.py
@@ -29,7 +29,7 @@ class KeyboardConfigBase:
 
     def parse_options(self, props) -> int:
         oldsync = self.sync
-        self.sync = props.boolget("keyboard_sync", True)
+        self.sync = props.boolget("sync", True)
         return int(oldsync != self.sync)
 
     def get_hash(self) -> str:


### PR DESCRIPTION
keyboard-sync options in command line was not working.

The options is parsed in input.py as below:

https://github.com/Xpra-org/xpra/blob/775d435b83097b0d97d55b3173ab5d9503ee5971/xpra/server/mixins/input.py#L58
``` python
    def init(self, opts) -> None:
        props = typedict()
        keymap = props.setdefault("keymap", {})
        for option in ("sync", "layout", "layouts", "variant", "variants", "options"):
            v = getattr(opts, f"keyboard_{option}", None)
            if v is not None:
                keymap[option] = v
        self.keyboard_config = self.get_keyboard_config(props)
```

The client sends the keyboard config but it doesn't have keyboard sync data so the default value (True) is used.

With --keyboard-sync=no option, the client UI displays the option as off but it is not on the server side.