### PR TITLE
Fix --keyboard-sync command line option

### DIFF
--- a/xpra/server/keyboard_config_base.py
+++ b/xpra/server/keyboard_config_base.py
@@ -31,7 +31,8 @@ class KeyboardConfigBase:
 
     def parse_options(self, props: typedict) -> int:
         oldsync = self.sync
-        self.sync = props.boolget("sync", True)
+        keymap_dict = typedict(props.dictget("keymap") or {})
+        self.sync = keymap_dict.boolget("sync", True)
         return int(oldsync != self.sync)
 
     def get_hash(self) -> str:


### PR DESCRIPTION
The "sync" is not in prop but prop['keymap']

Check out the code below:
https://github.com/Xpra-org/xpra/blob/b16a48f6137e08f43fc38b4d96d16d49b3392ed7/xpra/server/mixins/input.py#L58