### PR TITLE
docs: fix typo in manpage

### DIFF
--- a/fs/share/man/man1/xpra.1
+++ b/fs/share/man/man1/xpra.1
@@ -130,7 +130,7 @@ The password need only be specified when the server authentication module
 requires it.
 .P
 .SS vnc://[[USERNAME][:PASSWORD]@]HOST[:VNC_PORT]/
-Connect using ther RFB protocol. (aka VNC)
+Connect using the RFB protocol. (aka VNC)
 This mode only works against VNC servers or an xpra server in desktop or
 shadow mode.
 .\" --------------------------------------------------------------------


### PR DESCRIPTION
Minor spelling mistake in xpra.1 manpage. 