### PR TITLE
Windows client: printing to local device throws an exception in PDFIUM_Print.exe

### DIFF
--- a/xpra/platform/win32/pdfium.py
+++ b/xpra/platform/win32/pdfium.py
@@ -145,10 +145,11 @@ def do_print_pdf(hdc, title=b"PDF Print Test", pdf_data=None):
                 log("FPDF_LoadPage()=%s page %i loaded", page, i)
                 StartPage(hdc)
                 FPDF_RenderPage(hdc, page, x, y, w, h, rotate, flags)
-                FPDF_ClosePage(hdc)
                 EndPage(hdc)
+                FPDF_ClosePage(page)
                 log("FPDF_RenderPage page %i rendered", i)
         finally:
+            FPDF_CloseDocument(doc)
             EndDoc(hdc)
     finally:
         FPDF_DestroyLibrary()


### PR DESCRIPTION
XPRA-Version: 6.2.1-r0
Server: Fedora Linux 40, xpra-6.2.1-r0

printing a document using a local windows printer throws an exception in PDFIUM_Print.exe

### Reason:
calling FPDF_ClosePage with wrong ariable
