### PR TITLE
#4427 mark auto encoding as-is

### DIFF
--- a/xpra/client/gtk3/tray_menu.py
+++ b/xpra/client/gtk3/tray_menu.py
@@ -82,7 +82,7 @@ CLIPBOARD_DIRECTION_NAME_TO_LABEL = reverse_dict(CLIPBOARD_DIRECTION_LABEL_TO_NA
 SERVER_NOT_SUPPORTED = "Not supported by the server"
 
 # 'auto' is recorded as '' unfortunately:
-GENERIC_ENCODINGS = ("", "stream", "grayscale")
+GENERIC_ENCODINGS = ("auto", "stream", "grayscale")
 
 
 class GTKTrayMenu(MenuHelper):

--- a/xpra/client/mixins/encodings.py
+++ b/xpra/client/mixins/encodings.py
@@ -299,7 +299,7 @@ class Encodings(StubClientMixin):
     def set_encoding(self, encoding: str) -> None:
         log("set_encoding(%s)", encoding)
         if encoding == "auto":
-            self.encoding = ""
+            self.encoding = "auto"
         else:
             encodings = self.get_encodings()
             if encoding not in encodings:


### PR DESCRIPTION
Fix #4427 
Label Auto encoding as "auto" all the time.