### PR TITLE
#4442 Fix manifest and embed it

### DIFF
--- a/packaging/MSWindows/BUILD.py
+++ b/packaging/MSWindows/BUILD.py
@@ -777,9 +777,16 @@ def add_manifests() -> None:
         # these are only included in full builds:
         "GTK_info", "NativeGUI_info", "Screenshot", "Xpra-Shadow",
     ]
+    with open('packaging/MSWindows/exe.manifest', 'r') as file:
+        xml_file_content = file.read()
+    zero_padded_version = version_info.padded
+    xml_file_content = xml_file_content.replace("XPRA_ZERO_PADDED_VERSION", zero_padded_version)
+    with open('packaging/MSWindows/exe.manifest.tmp', 'w') as file:
+        file.write(xml_file_content)
     for exe in EXES:
         if os.path.exists(f"{DIST}/{exe}.exe"):
-            copyfile("packaging/MSWindows/exe.manifest", f"{DIST}/{exe}.exe.manifest")
+            copyfile("packaging/MSWindows/exe.manifest.tmp", f"{DIST}/{exe}.exe.manifest")
+    os.remove('packaging/MSWindows/exe.manifest.tmp')
 
 
 def gen_caches() -> None:

--- a/packaging/MSWindows/BUILD.sh
+++ b/packaging/MSWindows/BUILD.sh
@@ -571,14 +571,16 @@ popd > /dev/null
 
 
 echo "* Adding manifest"
+sed "s/XPRA_ZERO_PADDED_VERSION/$ZERO_PADDED_VERSION/" packaging/MSWindows/exe.manifest > packaging/MSWindows/exe.manifest.tmp
 for exe in Bug_Report Xpra-Launcher Xpra Xpra_cmd; do
-  cp packaging/MSWindows/exe.manifest ./dist/${exe}.exe.manifest
+  cp packaging/MSWindows/exe.manifest.tmp ./dist/${exe}.exe.manifest
 done
 if [ "${DO_FULL}" == "1" ]; then
 	for exe in GTK_info NativeGUI_info Screenshot Xpra-Shadow; do
-	  cp packaging/MSWindows/exe.manifest ./dist/${exe}.exe.manifest
+	  cp packaging/MSWindows/exe.manifest.tmp ./dist/${exe}.exe.manifest
 	done
 fi
+rm packaging/MSWindows/exe.manifest.tmp
 
 
 echo "* Generating gdk pixbuf loaders.cache"

--- a/packaging/MSWindows/exe.manifest
+++ b/packaging/MSWindows/exe.manifest
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+    <assemblyIdentity
+        type="win32"
+        name="Xpra"
+        version="XPRA_ZERO_PADDED_VERSION"
+    />
     <trustInfo xmlns="urn:schemas-microsoft-com:asm.v3">
         <security>
             <requestedPrivileges>
@@ -11,10 +16,10 @@
         <windowsSettings>
             <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
             <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
-            <gdiScaling>false</gdiScaling>
-            <disableWindowFiltering>true</disableWindowFiltering>
-            <highResolutionScrollingAware>true</highResolutionScrollingAware>
-            <printerDriverIsolation>true</printerDriverIsolation>
+            <gdiScaling xmlns="http://schemas.microsoft.com/SMI/2017/WindowsSettings">false</gdiScaling>
+            <disableWindowFiltering xmlns="http://schemas.microsoft.com/SMI/2011/WindowsSettings">true</disableWindowFiltering>
+            <highResolutionScrollingAware xmlns="http://schemas.microsoft.com/SMI/2013/WindowsSettings">true</highResolutionScrollingAware>
+            <printerDriverIsolation xmlns="http://schemas.microsoft.com/SMI/2011/WindowsSettings">true</printerDriverIsolation>
         </windowsSettings>
     </application>
 </assembly>

--- a/setup.py
+++ b/setup.py
@@ -1887,6 +1887,7 @@ if WIN32:
                 # targetDir               = "dist",
                 icon=f"fs/share/xpra/icons/{icon}",
                 target_name=f"{base_name}.exe",
+                manifest=f"dist/{base_name}.exe.manifest",
                 base=base,
             ))
 


### PR DESCRIPTION
Fix #4442, at Windows 11 Platform the DPI Aware is not affected.

1. it changes manifest and adds the required `assemblyIdentity` part. [1]
2. And fixed gdiScaling, disableWindowFiltering, highResolutionScrollingAware, printerDriverIsolation to correct namespace.  [1]
3. Modify build.py and build.sh to replace XPRA_ZERO_PADDED_VERSION with the currentnt version.
4. Specify the manifest location while using `cx_Freeze` to generate exe files. [2] 

[1]: Application manifests https://learn.microsoft.com/en-us/windows/win32/sbscs/application-manifests
[2]: cx_Freeze.Executable manifest https://cx-freeze.readthedocs.io/en/latest/setup_script.html