### PR TITLE
fix typo in cf39bb72de, backporting 075fa50ed3

### DIFF
--- a/xpra/x11/desktop/desktop_server.py
+++ b/xpra/x11/desktop/desktop_server.py
@@ -39,7 +39,7 @@ class XpraDesktopServer(DesktopServerBase):
         super().server_init()
         from xpra.x11.vfb_util import set_initial_resolution
         screenlog(f"server_init() randr={self.randr}, initial-resolutions={self.initial_resolutions}")
-        if not RandR.has_randr() or not self.initial_resolutions or not features.display:
+        if not RandR.has_randr() or not self.initial_resolutions or not server_features.display:
             return
         res = self.initial_resolutions
         if len(res) > 1:


### PR DESCRIPTION
The cherry pick of 075fa50ed3 (cf39bb72de) contains a typo that prevented me from starting xpra.

This trivial patch resolved it for me.

Thanks!