### PR TITLE
fix erroneously inverted condition

### DIFF
--- a/xpra/x11/server/core.py
+++ b/xpra/x11/server/core.py
@@ -246,7 +246,7 @@ class X11ServerCore(GTKServerBase):
             return
         if grp < 0:
             grp = 0
-        if self.current_keyboard_group != grp:
+        if self.current_keyboard_group == grp:
             keylog(f"set_keyboard_layout_group({grp}) ignored, value unchanged")
             return
         keylog(f"set_keyboard_layout_group({grp}) config={self.keyboard_config}, {self.current_keyboard_group=}")


### PR DESCRIPTION
Fixes #4462.

The bug was introduced by 84a5a81aa1fb41a3dac3b4c78d92b54b13278a5c.

Could be involved in other similar cases, like https://github.com/Xpra-org/xpra/issues/4445, https://github.com/Xpra-org/xpra/issues/3857#issuecomment-2563951319.