### PR TITLE
fix qp calculation for nvenc

### DIFF
--- a/xpra/codecs/nvidia/nvenc/encoder.pyx
+++ b/xpra/codecs/nvidia/nvenc/encoder.pyx
@@ -2048,7 +2048,7 @@ cdef class Encoder:
         QP_MAX_VALUE = 51       #255 for AV1!
 
         def qp(pct: float) -> int:
-            return QP_MAX_VALUE-max(0, min(QP_MAX_VALUE, round(QP_MAX_VALUE * pct)))
+            return QP_MAX_VALUE-max(0, min(QP_MAX_VALUE, round(QP_MAX_VALUE * pct / 100)))
         qpmin = qp(self.quality-10)
         qpmax = qp(self.quality+10)
         qp = min(QP_MAX_VALUE, max(0, round((qpmin + qpmax)//2)))


### PR DESCRIPTION
Currently, the quality parameter seems to be incorrectly handled inside the nvenc encoder, more specifically by the `qp()` function for converting between quality scales. The calculation this function carries out has to receive inputs between 0 and 1 in order to interpolate between 0 and `QP_MAX_VALUE`, but instead receives `self.quality +-10` directly, which lies between -9 and 110.

This leads to the quality parameter essentially being a binary choice between relatively high bandwidth (~35Mbps for 1080p@30fps) at perfect visual quality and really low bandwidth (~2.5Mbps for 1080p@30fps) at an unsatisfying visual quality.

This PR reintroduces the expected behavior of smoothly moving between these two states based on the quality parameter by first mapping the argument from [0, 100] to [0, 1].