### PR TITLE
Fix windows systeminfo codepage when setting up

### DIFF
--- a/fs/bin/add_build_info.py
+++ b/fs/bin/add_build_info.py
@@ -9,13 +9,12 @@
 
 import datetime
 from shutil import which
-from subprocess import Popen, PIPE, STDOUT, getstatusoutput
+from subprocess import Popen, PIPE, STDOUT, getstatusoutput, run
 from typing import Any
 from collections.abc import Sequence
 import socket
 import platform
 import os.path
-import re
 import sys
 
 
@@ -171,11 +170,18 @@ def get_platform_name() -> str:
         return "OpenBSD"
     if sys.platform.startswith("win"):
         try:
-            out = Popen('systeminfo', stdout=PIPE, text=True).communicate()[0]
-            match = re.search(r"OS Name:\s*(.*)", out)
-            if match:
-                return match.group(1).strip()
-            return "Windows unknown"
+            out = run(
+                [
+                    "powershell",
+                    "-NoProfile",
+                    "-Command",
+                    "$OutputEncoding = [Console]::OutputEncoding = New-Object System.Text.UTF8Encoding; (Get-CimInstance Win32_OperatingSystem).Caption | Out-String",
+                 ],
+                 capture_output=True,
+                 text=True,
+                 encoding="utf-8",
+            ).stdout.strip()
+            return out
         except OSError:
             pass
         return "Microsoft Windows"

--- a/packaging/MSWindows/SETUP.sh
+++ b/packaging/MSWindows/SETUP.sh
@@ -30,7 +30,7 @@ for x in cryptography cffi pycparser numpy pillow appdirs paramiko comtypes neti
 	$PACMAN ${XPKG}python-${x}
 done
 #not yet available for aarch64?:
-for x in cx-Freeze gssapi; do
+for x in cx-freeze gssapi; do
 	$PACMAN ${XPKG}python-${x}
 done
 


### PR DESCRIPTION
This is a byproduct when dealing with the problem in https://github.com/Xpra-org/xpra/issues/4503#issuecomment-2659339897

In the last discussion, we found that when running `python3 packaging/MSWindows/BUILD.py`, there are problems when calling `systeminfo`:
1. The titles (like "OS Name") are not in English if user's computer is in other language
2. I got text's encoding in `cp950` since I'm using a computer in Traditional Chinese
3. Output of "OS Name"("作業系統名稱" in my case) contains non-English contents

For the first two problems, I've solved in this PR and currently the output is something like "Microsoft Windows 10 企業版 LTSC".
I don't see the string being used other than showing in build info, so I guess texts not in English here works, as long as it's utf-8?

---

Meanwhile, there's still a little got-cha regarding `cx-freeze`😉
Fixed in this PR as well