### PR TITLE
Bugfix: Include pam_*.h within the security/ subdirectory

### DIFF
--- a/xpra/platform/pam.pyx
+++ b/xpra/platform/pam.pyx
@@ -32,12 +32,12 @@ cdef extern from "string.h":
 cdef extern from "stdlib.h":
     void *calloc(size_t nitems, size_t size)
 
-cdef extern from "pam_misc.h":
+cdef extern from "security/pam_misc.h":
     ctypedef struct pam_handle_t:
         pass
     void misc_conv(int num_msg, const pam_message **msgm, pam_response **response, void *appdata_ptr)
 
-cdef extern from "pam_appl.h":
+cdef extern from "security/pam_appl.h":
     struct pam_conv:
         void *conv
         #int (*conv)(int num_msg, const pam_message **msg, pam_response **resp, void *appdata_ptr)


### PR DESCRIPTION
Including these headers was never supposed to work without the security/ subdirectory in the include directive, and PAM 1.7.0 (specifically [941bfc1de4c8d4963c8b9d63d32fed391f1476c8](https://github.com/linux-pam/linux-pam/commit/941bfc1de4c8d4963c8b9d63d32fed391f1476c8)) fixed the pkgconfig files so it no longer works without that