### PR TITLE
#4534 home must be writable

### DIFF
--- a/xpra/x11/vfb_util.py
+++ b/xpra/x11/vfb_util.py
@@ -174,7 +174,8 @@ def get_xauthority_path(display_name: str) -> str:
     assert POSIX
     # pylint: disable=import-outside-toplevel
     from xpra.platform.posix.paths import _get_xpra_runtime_dir
-    has_home = os.path.exists(os.path.expanduser("~"))
+    expanded_home = os.path.expanduser("~")
+    has_home = os.path.exists(expanded_home) and is_writable(expanded_home, getuid(), getgid())
     if PRIVATE_XAUTH or (not has_home and os.environ.get("XDG_RUNTIME_DIR")):
         d = _get_xpra_runtime_dir()
         if XAUTH_PER_DISPLAY:
@@ -183,7 +184,7 @@ def get_xauthority_path(display_name: str) -> str:
             filename = "Xauthority"
     else:
         if has_home:
-            d = "~/"
+            d = expanded_home
         else:
             d = os.environ.get("TMPDIR", "/tmp")
         filename = ".Xauthority"


### PR DESCRIPTION
Fixes #4534

With this and setting XPRA_SOCKET_DIRS = "/var/run/pico-remote-play-assistant/xpra", I successfully got Xpra running in a DynamicUser systemd unit (along with some other generic configs).

I only intended to host some basic Windows service applications on my server, so it was tested with `--minimal`. I do want to use the web UI, so the final command line looks like this (plus some Nix variables):

```
        ${lib.getExe cfg.xpra.package} start \
          --daemon=off \
          --minimal=yes \
          --websocket-upgrade=yes \
          --bind-tcp=${cfg.listenAddress}:${builtins.toString cfg.port} \
          --auth=${cfg.auth} \
          ${lib.getExe cfg.package}
```

This got everything I wanted working, and I'm happy now :D

Without this PR, I can work around the original issue with setting XPRA_PRIVATE_XAUTH = 1, but that feels like misuse: I don't really care of XAUTH is private or not. So this looks like a cleaner approach.

---

I also tried to see if I can come up with some alternatives for XPRA_SOCKET_DIRS. Maybe add `$XDG_RUNTIME_DIR/xpra/sockets` to `do_get_socket_dirs` list? But I'm not sure if that's the intention of the code, so I avoided to change it.