### PR TITLE
Fix apt-get install --no-install-recommends xpra when there's no adduser package

### DIFF
--- a/packaging/debian/xpra/control
+++ b/packaging/debian/xpra/control
@@ -144,6 +144,8 @@ Depends: xpra-common (= ${binary:Version})
 #        ,xserver-xorg-video-dummy
         ,xvfb
         ,keyboard-configuration
+# addgroup:
+        ,adduser
 Recommends: xpra-codecs (= ${binary:Version})
         ,xpra-audio-server
         ,xpra-codecs-extras (= ${binary:Version})


### PR DESCRIPTION
xpra-server postinst depends on addgroup command, but does not list dependency on adduser package which provides such command.

This issue can be replicated in container, please let me know if you'd like me to provide a reproduction.