### PR TITLE
Fix reconnect for xpra seamless ... <command>

### DIFF
--- a/tests/unittests/unit/scripts/main_test.py
+++ b/tests/unittests/unit/scripts/main_test.py
@@ -25,6 +25,7 @@ from xpra.scripts.main import (
     check_display,
     find_session_by_name,
     find_mode_pos,
+    strip_attach_extra_positional_args,
 )
 from xpra.net.connect import connect_to, get_host_target_string
 
@@ -82,6 +83,16 @@ class TestMain(unittest.TestCase):
             '--start-child=rstudio',
         ]
         assert find_mode_pos(args, "seamless")==1
+
+    def test_strip_attach_extra_positional_args(self):
+        cmdline = ["xpra", "attach", "ssh://localhost/2", "dolphin"]
+        assert strip_attach_extra_positional_args(cmdline) == ["xpra", "attach", "ssh://localhost/2"]
+
+        cmdline = ["xpra", "attach", "ssh://localhost/2", "--encoding", "h264"]
+        assert strip_attach_extra_positional_args(cmdline) == cmdline
+
+        cmdline = ["xpra", "attach", "ssh://localhost/2", "--encoding", "h264", "dolphin"]
+        assert strip_attach_extra_positional_args(cmdline) == ["xpra", "attach", "ssh://localhost/2", "--encoding", "h264"]
 
     def test_host_parsing(self):
         try:


### PR DESCRIPTION
 drop implicit positional start-child args when re-execing attach

## Problem
  On reconnect, xpra re-execs itself using attach. When the original invocation used the “positional command” convenience syntax (eg xpra seamless ssh://host 'dolphin'), the non-connection positional argument
  is treated as an implicit --start-child during the initial run, but the raw token (dolphin) remains in the original cmdline. The reconnect path reuses that cmdline, rewrites seamless → attach, and only
  removes --start* options. This leaves a stray positional token after the display, so attach interprets it as a second display argument and fails with:

  too many arguments to choose a display (2): ['ssh://.../2', 'dolphin']

  This is most visible on macOS because reconnect/attach defaults are commonly enabled there, but the bug is platform-agnostic.

## Solution
  Sanitize the argv used for reconnect after rewriting to attach:

  - Keep xpra ... attach <display-or-uri>
  - Preserve subsequent options (including --opt value and --opt=value)
  - Drop any extra positional arguments after the display (these represent “implicit start-child” tokens from the original seamless invocation, and are invalid for attach)

  Implemented as a small helper and applied only in the reconnect path for remote server start.

## Changes

  - xpra/scripts/main.py: add strip_attach_extra_positional_args() and call it before exec_reconnect() in run_remote_server().
  - tests/unittests/unit/scripts/main_test.py: add test_strip_attach_extra_positional_args to prevent regressions.

## How to verify

  - Unit test: python3 -m unittest -q tests.unittests.unit.scripts.main_test.TestMain.test_strip_attach_extra_positional_args
  - Manual: run xpra seamless ssh://<host>/<display> 'dolphin' with reconnect enabled, induce a disconnect, confirm reconnect no longer errors with “too many arguments to choose a display”.
