### PR TITLE
Fix wrong include path for AMF headers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2958,7 +2958,7 @@ if amf_ENABLED:
         amf_kwargs = pkgconfig("amf")
     except ValueError:
         amf_kwargs = {
-            "extra_compile_args": "-I" + find_header_file("AMF", isdir=True) + "/AMF",
+            "extra_compile_args": "-I" + find_header_file("AMF", isdir=True),
             # "extra_link_args": ("-lpam", "-lpam_misc"),
         }
         print(f"using default amf args: {amf_kwargs}")


### PR DESCRIPTION
I have noticed that the xpra package on Arch Linux will not build on the latest versions if the AMF headers are installed. The build would fail with the message that it cannot find `core/Result.h`, included from [here](https://github.com/Xpra-org/xpra/blob/master/xpra/codecs/amf/amf.pxd#L36).

I noticed the generated compiler flags include `-I/usr/include/AMF/AMF` - a path that does not exist on my system, however `/usr/include/AMF` does, and within that path `core/Result.h` does exist. The change in this PR seems to fix it up.

I have no idea why `/AMF` would ever need to be explicitly appended here, but maybe I missed something.
