### PR TITLE
#4384 fix --resize-display=yes:none not working

### DIFF
--- a/xpra/scripts/server.py
+++ b/xpra/scripts/server.py
@@ -1221,7 +1221,9 @@ def do_run_server(script_file: str, cmdline: list[str], error_cb: Callable, opts
                 # "off:1080p" -> "1080p"
                 # "4k" -> "4k"
                 sizes = opts.resize_display.split(":", 1)[-1]
-                vfb_geom = parse_resolutions(sizes, opts.refresh_rate)[0]
+                resolutions = parse_resolutions(sizes, opts.refresh_rate)
+                if resolutions:
+                    vfb_geom = resolutions[0]
             fps = 0
             if opts.refresh_rate:
                 fps = get_refresh_rate_for_value(opts.refresh_rate, 60)

--- a/xpra/x11/subsystem/display.py
+++ b/xpra/x11/subsystem/display.py
@@ -135,7 +135,8 @@ class X11DisplayManager(DisplayManager):
             # ie: "off:1080p"
             onoff, sizes = opts.resize_display.split(":", 1)
         try:
-            self.initial_resolutions = parse_resolutions(sizes, opts.refresh_rate) or self.get_default_initial_res()
+            res = parse_resolutions(sizes, opts.refresh_rate)
+            self.initial_resolutions = res if res is not None else self.get_default_initial_res()
         except ValueError:
             self.initial_resolutions = self.get_default_initial_res()
         log("initial_resolutions(%s, %s)=%s", sizes, opts.refresh_rate, self.initial_resolutions)


### PR DESCRIPTION
## Summary

Fixes dynamic display resizing not working with XFCE4 (and similar desktop environments) when using the HTML5 client.

The workaround `--resize-display=yes:none` mentioned in #4384 doesn't actually work due to two bugs. This PR fixes both.

## Problem

When connecting to an XFCE4 desktop session via HTML5 client, resizing the browser window does not resize the remote desktop. The resolution stays stuck at the default (1920x1080).

The expected behavior with `--resize-display=yes:none` is that **no** initial resolution is set, allowing the client to dynamically control the display size.

## Root Cause

Two bugs prevent `--resize-display=yes:none` from working:

### 1. IndexError in `server.py`

```python
vfb_geom = parse_resolutions(sizes, opts.refresh_rate)[0]
```

When `parse_resolutions("none")` returns `()`, accessing `[0]` crashes:
```
IndexError: tuple index out of range
```

### 2. Empty tuple treated as falsy in `display.py`

```python
self.initial_resolutions = parse_resolutions(...) or self.get_default_initial_res()
```

Since `()` is falsy in Python, `() or default` always returns `default`. So even when `:none` is specified, the 1920x1080 fallback is silently used, preventing dynamic resizing.

## Testing

```bash
xpra start-desktop :100 \
    --bind-tcp=127.0.0.1:15151 \
    --html=on \
    --start=xfce4-session \
    --resize-display=yes:none
```

**Before fix:**
- Server crashes with IndexError, OR
- Resolution stuck at 1920x1080, resizing browser has no effect

**After fix:**
- Server starts without initial resolution
- Resizing browser window dynamically resizes XFCE4 desktop

## Related

- #4384 - Desktop WM-resolution fixed despite `--resize-display=yes`