### PR TITLE
fix Window Encoders section in Statistics tab

### DIFF
--- a/xpra/gtk/dialogs/session_info.py
+++ b/xpra/gtk/dialogs/session_info.py
@@ -1201,16 +1201,19 @@ class SessionInfo(Gtk.Window):
 
     def get_window_encoder_stats(self) -> dict:
         window_encoder_stats = {}
-        # info["client"] is always {int: source_info} (one entry per connected client)
+        # info["client"] is {int: source_info} — find our client by uuid
         server_last_info = self.last_info()
-        window_dict = {}
         client_info = server_last_info.get("client", {})
+        window_dict = {}
         for source in (v for v in client_info.values() if isinstance(v, dict)):
+            if bytestostr(source.get("uuid", "")) != self.client.uuid:
+                continue
             w = source.get("window")
             if isinstance(w, dict):
-                window_dict.update(w)
+                window_dict = w
+                break
         if window_dict:
-            id_to_window = getattr(self.client, "_id_to_window", {})
+            id_to_window = self.client._id_to_window
             for k, v in window_dict.items():
                 with log.trap_error("Error: cannot lookup window dict"):
                     wid = int(k)
@@ -1225,7 +1228,7 @@ class SessionInfo(Gtk.Window):
                             continue
                         stats = {"": last_used}
                     win = id_to_window.get(wid)
-                    title = (win.get_title() if win and hasattr(win, "get_title") else "") or ""
+                    title = (win.get_title() if win else "") or ""
                     stats["title"] = (title[:40] + "…") if len(title) > 40 else title
                     window_encoder_stats[wid] = stats
         return window_encoder_stats


### PR DESCRIPTION
The "Window Encoders" section in the Statistics tab of the session info dialog
has a bug that make it invisible and non-functional:

`populate_statistics` called `get_children()` and removed *all* children of
`encoder_info_box` including the "Window Encoders" title widget added in
`__init__`, then never re-added it. The section became invisible after the first
refresh cycle.

**Fix:** Only remove and replace encoder labels (children at index 1+), leaving
the title widget at index 0 untouched. Labels are only replaced when fresh data
is available.

### Additional improvements

- **Layout:** Changed `encoder_info_box` from `HBox` to `VBox` so multiple
  windows stack vertically rather than overflowing horizontally.
- **Spacing:** Added `margin_top=20` to match the padding used by the stats
  grid above.
- **Non-video encodings:** When no video encoder is active, falls back to
  `last_used` (e.g. `webp`, `png`) so the section always shows the current
  encoding rather than going blank.
- **Window titles:** Each entry now shows the window title (truncated to 40
  characters) alongside the window ID and encoder, making it easier to identify
  which window is using which encoder.
- **Tooltip:** The encoder detail tooltip now excludes the internal `"title"`
  key in addition to the encoder type name already shown in the label.