### PR TITLE
server/source/encoding: propagate min-speed/min-quality to existing window sources

### DIFF
--- a/xpra/server/source/encoding.py
+++ b/xpra/server/source/encoding.py
@@ -367,6 +367,10 @@ class EncodingsConnection(StubClientConnection):
         if ms > 0 and (s <= 0 or s > ms):
             self.default_encoding_options["min-speed"] = ms
         log("default encoding options: %s", self.default_encoding_options)
+        if ms > 0:
+            self.set_min_speed(ms)
+        if mq > 0:
+            self.set_min_quality(mq)
         self.auto_refresh_delay = c.intget("auto_refresh_delay", 0)
 
         # are we going to need a cuda context?


### PR DESCRIPTION
## Problem

When a client reconnects to a server that has existing windows, or when a
client sends `min-speed`/`min-quality` values during the initial encoding
capability handshake while windows already exist, those floors are not applied
to any `WindowSource` objects that were created before `parse_encoding_caps()`
ran.

`parse_encoding_caps()` correctly resolves the negotiated `min-speed` and
`min-quality` values and stores them in `default_encoding_options`, but it
never calls `set_min_speed()`/`set_min_quality()`. The `set_*` methods iterate
over all existing `WindowSource` objects and update their stored floor values.
Without that call, existing windows silently ignore the client's requested
minimums until they are recreated.

The result: a client that requests `min-speed=70` (e.g. to prevent the batch
delay heuristic from dropping encoder speed below that floor) will find the
setting ignored for any window that pre-existed the capability exchange.

## Fix

After `ms`/`mq` are resolved and written to `default_encoding_options`, call
`set_min_speed(ms)` and `set_min_quality(mq)` to propagate the values to all
existing window sources immediately.

The guards (`if ms > 0`) match the existing pattern used in the same function
for `default_encoding_options`, ensuring we don't propagate a zero/unset value.

## Testing

Reproduce by connecting to a server with existing windows (e.g. after a network
interruption causes a reconnect) and verifying that `xpra info` shows the
client's `min-speed`/`min-quality` reflected in the per-window encoder stats
immediately after reconnect, rather than only after windows are recreated.

Originally tested on Ubuntu 24.04 on the 6.4 branch, then ported to master.