### PR TITLE
Send full encoding caps to clients after background codec init

### DIFF
--- a/tests/unittests/unit/server/subsystem/encoding_test.py
+++ b/tests/unittests/unit/server/subsystem/encoding_test.py
@@ -6,8 +6,23 @@
 
 import unittest
 
-from xpra.util.objects import AdHocStruct
+from xpra.util.objects import AdHocStruct, typedict
 from unit.server.subsystem.servermixintest_util import ServerMixinTest
+
+
+def _make_opts():
+    opts = AdHocStruct()
+    opts.encoding = ""
+    opts.encodings = ["rgb", "png"]
+    opts.quality = 0
+    opts.min_quality = 20
+    opts.speed = 0
+    opts.min_speed = 20
+    opts.video = True
+    opts.video_scaling = "auto"
+    opts.video_encoders = []
+    opts.csc_modules = []
+    return opts
 
 
 class EncodingMixinTest(ServerMixinTest):
@@ -15,27 +30,63 @@ class EncodingMixinTest(ServerMixinTest):
     def test_encoding(self):
         from xpra.server.subsystem.encoding import EncodingServer
         from xpra.server.source.encoding import EncodingsConnection
-        opts = AdHocStruct()
-        opts.encoding = ""
-        opts.encodings = ["rgb", "png"]
-        opts.quality = 0
-        opts.min_quality = 20
-        opts.speed = 0
-        opts.min_speed = 20
-        opts.video = True
-        opts.video_scaling = "auto"
-        opts.video_encoders = []
-        opts.csc_modules = []
+        opts = _make_opts()
         self._test_mixin_class(EncodingServer, opts, {
-            "encodings.core" : opts.encodings,
+            "encodings.core": opts.encodings,
         }, EncodingsConnection)
         self.handle_packet(("quality", 10))
-        #assert self.mixin.get_info(self.protocol).get("encodings").get
-        #    "quality"       : self._process_quality,
-        #    "min-quality"   : self._process_min_quality,
-        #    "speed"         : self._process_speed,
-        #    "min-speed"     : self._process_min_speed,
-        #    "encoding"      : self._process_encoding,
+
+    def _setup_encoding(self):
+        from xpra.server.subsystem.encoding import EncodingServer
+        from xpra.server.source.encoding import EncodingsConnection
+        opts = _make_opts()
+        self._test_mixin_class(EncodingServer, opts, {
+            "encodings.core": opts.encodings,
+        }, EncodingsConnection)
+        # register the source so reinit_encodings can find it
+        self.mixin._server_sources[self.protocol] = self.source
+        # ensure the source wants encoding caps so threaded_init_complete proceeds
+        self.source.wants = ["encodings", "features"]
+        # capture packets sent to the client
+        packets = []
+        self.source.send_async = lambda pt, *a, **kw: packets.append(pt)
+        return packets
+
+    def test_reinit_encodings_sends_caps(self):
+        """reinit_encodings() should push full encoding capabilities to connected clients."""
+        import xpra.server.subsystem.encoding as enc_mod
+        from xpra.net.common import BACKWARDS_COMPATIBLE
+        packets = self._setup_encoding()
+        self.source.reinit_encoders = lambda: None
+        orig = enc_mod.is_windows_source
+        enc_mod.is_windows_source = lambda _ss: True
+        try:
+            self.mixin.reinit_encodings()
+        finally:
+            enc_mod.is_windows_source = orig
+        expected = "encodings" if BACKWARDS_COMPATIBLE else "encoding-set"
+        self.assertIn(expected, packets,
+                      f"reinit_encodings should send {expected!r} to update client encoding capabilities")
+
+    def test_add_new_client_sends_caps_when_init_done(self):
+        """add_new_client() should send encoding caps immediately when threaded setup is complete."""
+        from xpra.net.common import BACKWARDS_COMPATIBLE
+        packets = self._setup_encoding()
+        self.mixin.threaded_encoding_done = True
+        self.mixin.add_new_client(self.source, typedict(), True, 0)
+        expected = "encodings" if BACKWARDS_COMPATIBLE else "encoding-set"
+        self.assertIn(expected, packets,
+                      f"add_new_client should send {expected!r} when encoding setup is complete")
+
+    def test_add_new_client_defers_caps_when_init_pending(self):
+        """add_new_client() should not send encoding caps while threaded setup is still running."""
+        from xpra.net.common import BACKWARDS_COMPATIBLE
+        packets = self._setup_encoding()
+        self.mixin.threaded_encoding_done = False
+        self.mixin.add_new_client(self.source, typedict(), True, 0)
+        expected = "encodings" if BACKWARDS_COMPATIBLE else "encoding-set"
+        self.assertNotIn(expected, packets,
+                         "add_new_client should not send encoding caps while setup is still running")
 
 
 def main():

--- a/xpra/server/subsystem/encoding.py
+++ b/xpra/server/subsystem/encoding.py
@@ -8,7 +8,7 @@ from typing import Any
 from collections.abc import Sequence
 
 from xpra.util.env import envint
-from xpra.os_util import OSX
+from xpra.os_util import OSX, gi_import
 from xpra.net.common import Packet, FULL_INFO, BACKWARDS_COMPATIBLE
 from xpra.util.objects import typedict
 from xpra.util.thread import start_thread
@@ -20,6 +20,7 @@ from xpra.codecs.video import getVideoHelper
 from xpra.server.subsystem.stub import StubServerMixin
 from xpra.log import Logger
 
+GLib = gi_import("GLib")
 log = Logger("encoding")
 
 INIT_DELAY = envint("XPRA_ENCODER_INIT_DELAY", 0)
@@ -71,6 +72,7 @@ class EncodingServer(StubServerMixin):
         self.default_encoding: str = ""
         self.scaling_control = None
         self.video = True
+        self.threaded_encoding_done = False
 
     def init(self, opts) -> None:
         self.encoding = opts.encoding
@@ -104,6 +106,7 @@ class EncodingServer(StubServerMixin):
 
     def reinit_encodings(self, *args) -> None:
         self.init_encodings()
+        self.threaded_encoding_done = True
         # any window mapped before the threaded init completed
         # may need to re-initialize its list of encodings:
         log("reinit_encodings()", args)
@@ -111,6 +114,15 @@ class EncodingServer(StubServerMixin):
             if is_windows_source(ss):
                 ss.reinit_encodings(self)
                 ss.reinit_encoders()
+            if hasattr(ss, "threaded_init_complete"):
+                ss.threaded_init_complete(self)
+
+    def add_new_client(self, ss, c: typedict, send_ui: bool, share_count: int) -> None:
+        # If the background encoding setup finished before this client connected,
+        # reinit_encodings() already ran with no sources and this client missed
+        # threaded_init_complete(). Send the full encoding capabilities now.
+        if getattr(self, "threaded_encoding_done", False) and hasattr(ss, "threaded_init_complete"):
+            ss.threaded_init_complete(self)
 
     def threaded_encoding_setup(self) -> None:
         if INIT_DELAY > 0:
@@ -122,7 +134,8 @@ class EncodingServer(StubServerMixin):
         if self.video:
             # load video codecs:
             getVideoHelper().init()
-        self.init_encodings()
+        # dispatch to the main thread: updates encodings and notifies connected clients
+        GLib.idle_add(self.reinit_encodings)
 
     def cleanup(self) -> None:
         getVideoHelper().cleanup()


### PR DESCRIPTION
🤖 This PR was generated by Anthropic Claude (claude-sonnet-4-6).

**How this was found:** The Server Picture Encodings section of the client Session Info dialog
was showing only default encodings (`rgb32`, `rgb24`, `jpeg`, `png`) instead of the full set
including h264/nvenc. Claude diagnosed and applied a local module override in a prior session to
restore functionality. In a later session, Claude revisited the patch as a starting point for
upstreaming, diagnosed the root cause more deeply (tracing why `threaded_init_complete()` was
never called — dead in both v6.4.x and master, but for different reasons), determined the local
patch's approach would not work on master, and designed and implemented a correct fix using
`GLib.idle_add` + a `threaded_encoding_done` flag. Tests were written first (TDD), then
implementation.

### Problem

After `threaded_encoding_setup()` loads video codecs, clients never receive an updated encoding
capability packet. The Statistics dialog shows only the default encodings (`rgb32`, `rgb24`,
`jpeg`, `png`) and the manual encoding selection menu is limited to those — even though the server
is actually encoding with h264/nvenc.

The actual encoding *does* switch correctly: `reinit_encoders()` is called on connected window
sources when init completes, so the server starts using hardware encoders. The missing piece is
the informational `threaded_init_complete()` packet back to the client, which updates
`server_core_encodings` for display and manual selection.

`threaded_init_complete()` has never been called from anywhere in the codebase. In master,
`threaded_encoding_setup()` called `init_encodings()` directly when done with no client
notification of any kind. The `init-thread-ended` signal that `reinit_encodings` was connected
to was also never emitted after the per-subsystem threading refactor, making that path doubly
dead.

### Fix

- After background codec loading completes, dispatch `reinit_encodings()` on the GLib main thread
  via `GLib.idle_add()` instead of calling `init_encodings()` directly. This ensures connected
  clients get `reinit_encoders()` followed by `threaded_init_complete()`, which sends the full
  encoding capability packet.
- Add `add_new_client()` to handle clients that connect after init has already completed:
  `reinit_encodings()` will have run with an empty source list and those clients would never
  receive `threaded_init_complete()`. Track `threaded_encoding_done` to distinguish this case —
  there is no other observable signal that `reinit_encodings()` has already fired.

### Tests

Three new tests in `encoding_test.py`:

- `test_reinit_encodings_sends_caps`: verifies `reinit_encodings()` sends the capability packet
  to connected clients
- `test_add_new_client_sends_caps_when_init_done`: verifies `add_new_client()` sends caps
  immediately when background init is already complete
- `test_add_new_client_defers_caps_when_init_pending`: verifies `add_new_client()` does not
  send caps while background init is still running