### PR TITLE
Fix nvenc race: allocate CUDA context on reinit if missing

### DIFF
--- a/xpra/server/source/encoding.py
+++ b/xpra/server/source/encoding.py
@@ -92,6 +92,15 @@ class EncodingsConnection(StubClientConnection):
     def reinit_encodings(self, server) -> None:
         self.server_core_encodings = server.core_encodings
         self.server_encodings = server.encodings
+        # If this client connected before nvenc finished loading, CUDA context allocation
+        # was skipped in parse_encoding_caps. Allocate it now if still missing.
+        if not self.cuda_device_context and not getattr(self, "mmap_enabled", False) and self.wants_cuda_device():
+            self.allocate_cuda_device_context()
+        # Propagate cuda context to any window sources created before it was available.
+        if self.cuda_device_context:
+            for ws in self.all_window_sources():
+                if not ws.cuda_device_context:
+                    ws.cuda_device_context = self.cuda_device_context
 
     def cleanup(self) -> None:
         self.cancel_recalculate_timer()
@@ -377,14 +386,16 @@ class EncodingsConnection(StubClientConnection):
         if getattr(self, "mmap_enabled", False):
             # not with mmap!
             return
-        common_encodings = set(x for x in self.encodings if x in self.server_encodings)
+        if not self.cuda_device_context and self.wants_cuda_device():
+            self.allocate_cuda_device_context()
+
+    def wants_cuda_device(self) -> bool:
         from xpra.codecs.loader import has_codec
-        want_cuda_device = any((
+        common_encodings = set(x for x in self.encodings if x in self.server_encodings)
+        return any((
             has_codec("nvenc") and {"h264", "h265", "av1"} & common_encodings,
             has_codec("enc_nvjpeg") and "jpeg" in common_encodings,
         ))
-        if want_cuda_device and not self.cuda_device_context:
-            self.allocate_cuda_device_context()
 
     def allocate_cuda_device_context(self):
         cudalog = Logger("cuda")


### PR DESCRIPTION
🤖 This PR was generated by Anthropic Claude (claude-sonnet-4-6).

**How this was found:** Log messages showed `RuntimeError: no cuda device context` on nvenc
encodes after reconnecting at server startup, and the Window Encoders section of the Statistics
tab was not showing nvenc. Claude diagnosed and applied a local module override in a prior session
to restore functionality. In a later session, Claude revisited the patch as a starting point for
upstreaming, diagnosed the race condition in `parse_encoding_caps()` more precisely, determined
the correct fix location (`reinit_encodings`, which runs after background codec loading
completes), and implemented it as a standalone PR.

### Problem

When a client connects before nvenc finishes loading in the background,
`parse_encoding_caps()` calls `has_codec("nvenc")` which returns `False` at that point, so
`allocate_cuda_device_context()` is never called. The connection's `cuda_device_context` remains
`None` permanently — there is no retry. Every subsequent nvenc encode then fails:

```
RuntimeError: no cuda device context
```

The server falls back to software encoders for the rest of the session. This race is easy to hit
at startup: a persistent client may reconnect within the first few seconds before
`threaded_encoding_setup()` has finished loading nvenc and initializing CUDA.

### Fix

In `reinit_encodings()`, which runs on the main thread after background codec loading completes,
check whether the CUDA context is still `None`. If nvenc or enc_nvjpeg is now available and the
client's negotiated encodings include a CUDA-backed codec, allocate the context then. Propagate
it to any window sources already created for this connection that also lack a context. Skip CUDA
allocation if the client is using mmap, matching the condition in `parse_encoding_caps()`.
Extracts `wants_cuda_device()` to deduplicate the codec detection logic shared with
`parse_encoding_caps()`.
