### PR TITLE
Fix session info connection time display

### DIFF
--- a/xpra/client/base/client.py
+++ b/xpra/client/base/client.py
@@ -10,7 +10,7 @@ import uuid
 import signal
 import socket
 import string
-from time import monotonic
+from time import time
 from typing import Any, NoReturn
 from types import FrameType
 from collections.abc import Callable, Sequence
@@ -73,7 +73,7 @@ class XpraClientBase(PacketDispatcher, ClientBaseClass):
             bc.__init__(self)
         self.init_packet_handlers()
         self.exit_code: ExitValue | None = None
-        self.start_time = int(monotonic())
+        self.start_time = int(time())
 
     def idle_add(self, fn: Callable, *args, **kwargs) -> int:
         ...

--- a/xpra/gtk/dialogs/session_info.py
+++ b/xpra/gtk/dialogs/session_info.py
@@ -890,10 +890,10 @@ class SessionInfo(Gtk.Window):
             self.label_row("Server Platform", cattr("_remote_platform"))
         self.server_load_label = self.label_row("Server Load")
         self.server_load_label.set_tooltip_text("Average over 1, 5 and 15 minutes")
-        self.session_started_label = self.label_row("Session Started")
+        self.session_started_label = self.label_row("Session Duration")
         if not self.show_client:
             return
-        self.session_connected_label = self.label_row("Session Connected")
+        self.session_connected_label = self.label_row("Connection Duration")
         self.input_packets_label = self.label_row("Packets Received")
         self.input_bytes_label = self.label_row("Bytes Received")
         self.output_packets_label = self.label_row("Packets Sent")


### PR DESCRIPTION
## Summary

- `client.start_time` was set with `monotonic()` (seconds since arbitrary boot epoch) but `settimedeltastr()` computes `time.time() - from_time` (wall-clock epoch seconds). The mismatch caused "Session Connected" to display an absurdly large elapsed time (effectively: epoch seconds minus uptime seconds ≈ years).
- Fix: use `time()` for `client.start_time`, consistent with how `server.start_time` is set in `server/core.py`.
- Rename "Session Started" → "Session Duration" and "Session Connected" → "Connection Duration" to accurately reflect that these labels show elapsed time, not timestamps.

---

> 🤖 This PR was created by [Anthropic Claude](https://claude.ai) (claude-sonnet-4-6) via [Claude Code](https://claude.ai/claude-code).
>
> **Prompt used:** "In client session info, it's showing the wrong 'Session Connected' time. I suspect the units are wrong (ms vs seconds or something?). Find and fix this bug."