### PR TITLE
Use content-type-aware scaling filters for desktop-scaling

### DIFF
--- a/tests/unittests/unit/client/cairo_scaling_test.py
+++ b/tests/unittests/unit/client/cairo_scaling_test.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+# ABOUTME: Tests for nearest-neighbor scaling filter selection in CairoBackingBase.
+# ABOUTME: Verifies filter choice based on content type, scale factor, and env overrides.
+
+# This file is part of Xpra.
+# Copyright (C) 2024 Antoine Martin <antoine@xpra.org>
+# Xpra is released under the terms of the GNU GPL v2, or, at your option, any
+# later version. See the file COPYING for details.
+
+import os
+import unittest
+
+import cairo
+
+from xpra.cairo.backing_base import get_scaling_filter
+
+
+class ScalingFilterTest(unittest.TestCase):
+
+    def test_text_integer_2x_uses_nearest(self):
+        self.assertEqual(get_scaling_filter("text", 2.0, 2.0), cairo.FILTER_NEAREST)
+
+    def test_text_integer_3x_uses_nearest(self):
+        self.assertEqual(get_scaling_filter("text", 3.0, 3.0), cairo.FILTER_NEAREST)
+
+    def test_text_non_integer_uses_best(self):
+        self.assertEqual(get_scaling_filter("text", 1.5, 1.5), cairo.FILTER_BEST)
+
+    def test_non_text_integer_2x_uses_good(self):
+        self.assertEqual(get_scaling_filter("browser", 2.0, 2.0), cairo.FILTER_GOOD)
+
+    def test_no_scaling_uses_best(self):
+        self.assertEqual(get_scaling_filter("text", 1.0, 1.0), cairo.FILTER_BEST)
+
+    def test_empty_content_type_uses_good(self):
+        self.assertEqual(get_scaling_filter("", 2.0, 2.0), cairo.FILTER_GOOD)
+
+    def test_asymmetric_integer_scale_uses_nearest(self):
+        self.assertEqual(get_scaling_filter("text", 2.0, 3.0), cairo.FILTER_NEAREST)
+
+    def test_asymmetric_mixed_scale_uses_best(self):
+        self.assertEqual(get_scaling_filter("text", 2.0, 1.5), cairo.FILTER_BEST)
+
+    def test_text_near_integer_2x_uses_nearest(self):
+        """Pixel rounding can produce scale factors like 1.95 or 2.05."""
+        self.assertEqual(get_scaling_filter("text", 1.95, 2.05), cairo.FILTER_NEAREST)
+
+    def test_text_outside_tolerance_uses_best(self):
+        """Text at non-integer scale uses Catmull-Rom (bicubic)."""
+        self.assertEqual(get_scaling_filter("text", 2.2, 2.2), cairo.FILTER_BEST)
+
+    def test_env_override_nearest(self):
+        old = os.environ.get("XPRA_SCALING_FILTER")
+        try:
+            os.environ["XPRA_SCALING_FILTER"] = "nearest"
+            self.assertEqual(get_scaling_filter("browser", 2.0, 2.0), cairo.FILTER_NEAREST)
+        finally:
+            if old is None:
+                os.environ.pop("XPRA_SCALING_FILTER", None)
+            else:
+                os.environ["XPRA_SCALING_FILTER"] = old
+
+    def test_env_override_bilinear(self):
+        old = os.environ.get("XPRA_SCALING_FILTER")
+        try:
+            os.environ["XPRA_SCALING_FILTER"] = "bilinear"
+            self.assertEqual(get_scaling_filter("text", 2.0, 2.0), cairo.FILTER_GOOD)
+        finally:
+            if old is None:
+                os.environ.pop("XPRA_SCALING_FILTER", None)
+            else:
+                os.environ["XPRA_SCALING_FILTER"] = old
+
+    def test_checkerboard_nearest_exact_pixel_doubling(self):
+        """Paint a 2x2 checkerboard, scale 2x with NEAREST, verify exact pixel doubling."""
+        # Create a 2x2 checkerboard: black/white/white/black
+        src = cairo.ImageSurface(cairo.Format.ARGB32, 2, 2)
+        ctx = cairo.Context(src)
+        # pixel (0,0) = black
+        ctx.set_source_rgb(0, 0, 0)
+        ctx.rectangle(0, 0, 1, 1)
+        ctx.fill()
+        # pixel (1,0) = white
+        ctx.set_source_rgb(1, 1, 1)
+        ctx.rectangle(1, 0, 1, 1)
+        ctx.fill()
+        # pixel (0,1) = white
+        ctx.set_source_rgb(1, 1, 1)
+        ctx.rectangle(0, 1, 1, 1)
+        ctx.fill()
+        # pixel (1,1) = black
+        ctx.set_source_rgb(0, 0, 0)
+        ctx.rectangle(1, 1, 1, 1)
+        ctx.fill()
+        src.flush()
+
+        # Scale 2x with NEAREST into a 4x4 surface
+        dst = cairo.ImageSurface(cairo.Format.ARGB32, 4, 4)
+        gc = cairo.Context(dst)
+        gc.scale(2, 2)
+        gc.set_source_surface(src, 0, 0)
+        gc.get_source().set_filter(cairo.FILTER_NEAREST)
+        gc.paint()
+        dst.flush()
+
+        # Read pixels — each source pixel should become an exact 2x2 block
+        buf = dst.get_data()
+        stride = dst.get_stride()
+
+        def pixel_rgb(x, y):
+            offset = y * stride + x * 4
+            # ARGB32 is stored as native-endian uint32; on little-endian: B, G, R, A
+            b, g, r = buf[offset], buf[offset + 1], buf[offset + 2]
+            return (r, g, b)
+
+        black = (0, 0, 0)
+        white = (255, 255, 255)
+        # Top-left 2x2 block should be black
+        for dy in range(2):
+            for dx in range(2):
+                self.assertEqual(pixel_rgb(dx, dy), black,
+                                 f"Expected black at ({dx},{dy})")
+        # Top-right 2x2 block should be white
+        for dy in range(2):
+            for dx in range(2, 4):
+                self.assertEqual(pixel_rgb(dx, dy), white,
+                                 f"Expected white at ({dx},{dy})")
+        # Bottom-left 2x2 block should be white
+        for dy in range(2, 4):
+            for dx in range(2):
+                self.assertEqual(pixel_rgb(dx, dy), white,
+                                 f"Expected white at ({dx},{dy})")
+        # Bottom-right 2x2 block should be black
+        for dy in range(2, 4):
+            for dx in range(2, 4):
+                self.assertEqual(pixel_rgb(dx, dy), black,
+                                 f"Expected black at ({dx},{dy})")
+
+
+def main():
+    unittest.main()
+
+
+if __name__ == '__main__':
+    main()

--- a/xpra/cairo/backing_base.py
+++ b/xpra/cairo/backing_base.py
@@ -9,7 +9,10 @@ from math import pi, sin
 from time import monotonic
 from typing import Any
 from collections.abc import Callable
-from cairo import Context, ImageSurface, Format, Operator, OPERATOR_OVER, LINE_CAP_ROUND
+from cairo import (
+    Context, ImageSurface, Format, Operator, OPERATOR_OVER, LINE_CAP_ROUND,
+    FILTER_NEAREST, FILTER_GOOD, FILTER_BEST,
+)
 
 from xpra.client.gui.paint_colors import get_paint_box_color
 from xpra.client.gui.window.backing import WindowBackingBase, fire_paint_callbacks, ALERT_MODE, PaintCallbacks
@@ -88,9 +91,28 @@ def cairo_paint_pointer_overlay(context, cursor_data, px: int, py: int, start_ti
     context.paint_with_alpha(alpha)
 
 
-def cairo_draw_backing(context, backing) -> None:
+def get_scaling_filter(content_type: str, sx: float, sy: float):
+    override = os.environ.get("XPRA_SCALING_FILTER", "").lower()
+    if override == "nearest":
+        return FILTER_NEAREST
+    if override == "bilinear":
+        return FILTER_GOOD
+    if "text" in content_type:
+        # use nearest-neighbor for text windows at integer upscale >= 2x
+        if (round(sx) >= 2 and round(sy) >= 2
+                and abs(sx - round(sx)) <= 0.1
+                and abs(sy - round(sy)) <= 0.1):
+            return FILTER_NEAREST
+        # use Catmull-Rom (bicubic) for text at non-integer scales
+        return FILTER_BEST
+    return FILTER_GOOD
+
+
+def cairo_draw_backing(context, backing, scaling_filter=None) -> None:
     context.set_operator(Operator.SOURCE)
     context.set_source_surface(backing, 0, 0)
+    if scaling_filter is not None:
+        context.get_source().set_filter(scaling_filter)
     context.paint()
 
 
@@ -103,6 +125,7 @@ class CairoBackingBase(WindowBackingBase):
         self.size = 0, 0
         self.render_size = 0, 0
         self.fps_image = None
+        self.content_type = ""
 
     def init(self, ww: int, wh: int, bw: int, bh: int) -> None:
         mod = self.size != (bw, bh) or self.render_size != (ww, wh)
@@ -309,7 +332,13 @@ class CairoBackingBase(WindowBackingBase):
         self.paint_backing_offset_border(context, w, h)
         if not self.clip_to_backing(context, w, h):
             return
-        cairo_draw_backing(context, backing)
+        # select scaling filter based on content type and desktop-scaling factor
+        scaling_filter = None
+        bw, bh = self.size
+        ww, wh = self.render_size
+        if bw and bh and (ww != bw or wh != bh):
+            scaling_filter = get_scaling_filter(self.content_type, ww / bw, wh / bh)
+        cairo_draw_backing(context, backing, scaling_filter)
         self.cairo_draw_pointer(context)
         self.cairo_draw_alert(context)
 

--- a/xpra/client/gui/window_base.py
+++ b/xpra/client/gui/window_base.py
@@ -215,6 +215,7 @@ class ClientWindowBase(ClientWidgetBase):
         w, h = self._size
         self._backing = self.make_new_backing(backing_class, w, h, bw, bh)
         self._backing.border = self.border
+        self._backing.content_type = self.content_type
         # soft dependency on `PointerWindow`:
         self._backing.default_cursor_data = getattr(self, "default_cursor_data", ())
         self._backing.gravity = self.window_gravity
@@ -495,6 +496,8 @@ class ClientWindowBase(ClientWidgetBase):
 
         if "content-type" in metadata:
             self.content_type = metadata.strget("content-type")
+            if self._backing:
+                self._backing.content_type = self.content_type
 
         if "actions" in metadata:
             self._actions = metadata.strtupleget("actions")


### PR DESCRIPTION
## Summary

- **Text windows at integer desktop-scaling >= 2x**: use `FILTER_NEAREST` for crisp pixel doubling with no interpolation blur
- **Text windows at non-integer desktop-scaling**: use `FILTER_BEST` (Catmull-Rom bicubic on pixman >= 0.33) for better edge preservation than bilinear
- **All other windows**: unchanged (`FILTER_GOOD` / bilinear)

Integer scale detection uses ±0.1 tolerance to handle pixel rounding (e.g. 1.9999 or 2.0001 from integer division).

Adds `XPRA_SCALING_FILTER` env var override (`nearest` or `bilinear`) for manual control.

Propagates `content_type` from window to backing so the filter can be selected per-window.

## Motivation

When `--desktop-scaling=2` on a high-DPI client, bilinear interpolation blurs rasterized text. For integer scale factors, nearest-neighbor produces sharper text (each pixel becomes a crisp NxN block). For non-integer factors, Catmull-Rom preserves sharp edges better than bilinear.

Relates to #3994, #4132, #4775.

## Files changed

- `xpra/cairo/backing_base.py` — `get_scaling_filter()` function and integration in `cairo_draw_backing` / `cairo_draw`
- `xpra/client/gui/window_base.py` — propagate `content_type` to backing on creation and metadata update
- `tests/unittests/unit/client/cairo_scaling_test.py` — 13 unit tests

## Test plan

- [x] 13 unit tests covering: text/non-text content types, integer/non-integer scales, tolerance boundary, env var overrides, visual pixel-doubling verification
- [ ] Manual: connect with `--desktop-scaling=2`, open xterm (content-type=text), verify sharp text
- [ ] Manual: open browser window, verify still uses bilinear (no change)
- [ ] Manual: connect with `--desktop-scaling=1.5`, verify text uses FILTER_BEST

## Attribution

This change was developed collaboratively by Andrew Chen and Anthropic's Claude (Opus 4.6). The work originated from investigating blurry text rendering when using `--desktop-scaling=2` on a high-DPI client connected to a low-DPI xpra server. Claude assisted with implementation, TDD, code review, and researching cairo/pixman filter behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)