### PR TITLE
Apply current cursor to newly-created windows

### DIFF
--- a/xpra/client/gtk3/client_base.py
+++ b/xpra/client/gtk3/client_base.py
@@ -184,6 +184,9 @@ class GTKXpraClient(GObjectClientAdapter, UIXpraClient):
         self.gl_max_viewport_dims = 0, 0
         self.gl_texture_size_limit = 0
         self._cursors = weakref.WeakKeyDictionary()
+        # Last cursor data applied; show_window() uses this to apply the
+        # current cursor to newly-created windows.
+        self._last_cursor_data: tuple = ()
         # frame request hidden window:
         self.frame_request_window = None
         # group leader bits:
@@ -930,6 +933,7 @@ class GTKXpraClient(GObjectClientAdapter, UIXpraClient):
             if cursor is None:
                 # use default:
                 cursor = get_default_cursor()
+        self._last_cursor_data = cursor_data
         for w in windows:
             w.set_cursor_data(cursor_data)
             # the cursor should only apply to the window contents (aka "drawingarea"),

--- a/xpra/client/subsystem/window/manager.py
+++ b/xpra/client/subsystem/window/manager.py
@@ -302,6 +302,11 @@ class WindowManagerClient(StubClientMixin):
 
     def show_window(self, wid: int, window, metadata, override_redirect: bool) -> None:
         window.show_all()
+        # apply the current cursor — without this, newly-shown windows
+        # show an arrow indefinitely (server doesn't resend cursor data):
+        last_cursor = getattr(self, "_last_cursor_data", ())
+        if last_cursor:
+            self.set_windows_cursor([window], last_cursor)
         if override_redirect and should_force_grab(metadata):
             log.warn("forcing grab for OR window %#x", wid)
             self.window_grab(wid, window)


### PR DESCRIPTION
## Problem

When a new window is created after the most recent cursor packet from the server, it shows the default arrow cursor. The server sends cursor data when the cursor changes and expects all windows to apply it, but windows that don't exist yet at that time have no way to recover the current cursor.

Since the server only sends cursor packets on actual cursor changes, the arrow persists indefinitely if the server-side cursor hasn't changed — typically until the client reconnects. This is most noticeable when opening new terminal or editor windows while an I-beam cursor is active.

## Solution

- Cache the last cursor data in `_last_cursor_data` on each `set_windows_cursor()` call
- In `show_window()`, after `window.show_all()` realizes the widget tree, apply the cached cursor to the newly-shown window

New windows immediately get the correct cursor with no dependency on future server packets.

The `show_window()` hook uses `getattr(self, "_last_cursor_data", ())` to access the cache defensively — if `CursorClient` isn't mixed in, it's a no-op. This follows the existing cross-mixin pattern (e.g., `CursorClient` already accesses `self._id_to_window` from `WindowClient`).

## Drawbacks

- Adds a `set_windows_cursor()` call per new window, which builds a `GdkCursor` from the cached data. This is a one-time cost at window creation and should be negligible.
- On cursor reset (empty cursor data), the cache is set to `()` and `show_window()` skips the apply, so new windows correctly get the system default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)