### PR TITLE
Add Win32 API signatures for cursor and window subclassing

### DIFF
--- a/xpra/platform/win32/common.py
+++ b/xpra/platform/win32/common.py
@@ -399,6 +399,12 @@ GetPhysicalCursorPos.restype = BOOL
 SetPhysicalCursorPos = user32.SetPhysicalCursorPos
 SetPhysicalCursorPos.argtypes = [INT, INT]
 SetPhysicalCursorPos.restype = BOOL
+SetCursor = user32.SetCursor
+SetCursor.argtypes = [HCURSOR]
+SetCursor.restype = HCURSOR
+IsWindow = user32.IsWindow
+IsWindow.argtypes = [HWND]
+IsWindow.restype = BOOL
 GetCursorInfo = user32.GetCursorInfo
 GetCursorInfo.argtypes = [POINTER(CURSORINFO)]
 GetCursorInfo.restype = BOOL
@@ -1043,3 +1049,27 @@ class PAINTSTRUCT(Structure):
         ('fIncUpdate', BOOL),
         ('rgbReserved', c_char * 32),
     ]
+
+
+comctl32 = WinDLL("comctl32", use_last_error=True)
+
+# LRESULT CALLBACK SubclassProc(HWND, UINT, WPARAM, LPARAM, UINT_PTR, DWORD_PTR)
+# https://learn.microsoft.com/en-us/windows/win32/api/commctrl/nc-commctrl-subclassproc
+SUBCLASSPROC = WINFUNCTYPE(
+    LRESULT,       # return
+    HWND,          # hWnd
+    UINT,          # uMsg
+    WPARAM,        # wParam
+    LPARAM,        # lParam
+    c_size_t,      # uIdSubclass (UINT_PTR)
+    c_size_t,      # dwRefData (DWORD_PTR)
+)
+SetWindowSubclass = comctl32.SetWindowSubclass
+SetWindowSubclass.argtypes = [HWND, SUBCLASSPROC, c_size_t, c_size_t]
+SetWindowSubclass.restype = BOOL
+RemoveWindowSubclass = comctl32.RemoveWindowSubclass
+RemoveWindowSubclass.argtypes = [HWND, SUBCLASSPROC, c_size_t]
+RemoveWindowSubclass.restype = BOOL
+DefSubclassProc = comctl32.DefSubclassProc
+DefSubclassProc.argtypes = [HWND, UINT, WPARAM, LPARAM]
+DefSubclassProc.restype = LRESULT


### PR DESCRIPTION
## Problem

There are no ctypes bindings for comctl32's window subclassing API (`SetWindowSubclass`, `RemoveWindowSubclass`, `DefSubclassProc`) or for `user32.SetCursor` and `user32.IsWindow` in `xpra.platform.win32.common`.

These are needed for safely intercepting Win32 window messages on HWNDs that xpra doesn't own (e.g., child HWNDs created by GTK's GL DrawingArea). The comctl32 subclassing API is the recommended approach — unlike `SetWindowLongW(GWL_WNDPROC)` (already used by `Win32Hooks`), `SetWindowSubclass` is chainable and handles multiple subclasses on the same HWND without conflicts.

## Solution

- Add `SetCursor` (set the current Win32 cursor) and `IsWindow` (validate an HWND) to the existing user32 bindings
- Add `comctl32` DLL handle, loaded via `WinDLL("comctl32", use_last_error=True)` consistent with user32/kernel32/gdi32
- Add `SUBCLASSPROC` callback type via `WINFUNCTYPE` with platform-portable parameter types (`c_size_t` for `UINT_PTR`/`DWORD_PTR`)
- Add `SetWindowSubclass`, `RemoveWindowSubclass`, `DefSubclassProc` with correct argtypes/restype per MSDN

## Drawbacks

None — these are pure declarations with no behavioral change. The comctl32 DLL is loaded at import time on Win32, but comctl32 is already loaded by GTK so this adds no new DLL dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)