### PR TITLE
Fix GL window cursor on Win32 via platform HWND subclass

### DIFF
--- a/tests/unittests/unit/client/gl_cursor_probe_test.py
+++ b/tests/unittests/unit/client/gl_cursor_probe_test.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+# This file is part of Xpra.
+# Copyright (C) 2026 Netflix, Inc.
+# Xpra is released under the terms of the GNU GPL v2, or, at your option, any
+# later version. See the file COPYING for details.
+# ABOUTME: Tests for the runtime HCURSOR offset probe used by the Win32 GL cursor fix.
+# ABOUTME: Verifies the probe discovers a valid offset and extracts working HCURSOR handles.
+
+import struct
+import unittest
+from ctypes import addressof, c_void_p, sizeof, create_string_buffer
+
+from xpra.os_util import WIN32
+
+
+def _make_fake_struct(fields):
+    """Create a fake C struct in memory with pointer-sized fields.
+    Returns (buffer, base_address)."""
+    ptr_size = sizeof(c_void_p)
+    buf = create_string_buffer(len(fields) * ptr_size)
+    fmt = "P" * len(fields)
+    struct.pack_into(fmt, buf, 0, *fields)
+    return buf
+
+
+class TestScanLogic(unittest.TestCase):
+    """Test the offset-scanning algorithm independent of Win32 APIs."""
+
+    def _scan_for_differing_valid_handles(self, ptr_a, ptr_b, scan_limit, is_valid_handle):
+        """Reimplementation of the core scan logic from _probe_hcursor_offset
+        for testing without Win32 dependencies."""
+        ptr_size = sizeof(c_void_p)
+        for offset in range(0, scan_limit, ptr_size):
+            val_a = c_void_p.from_address(ptr_a + offset).value or 0
+            val_b = c_void_p.from_address(ptr_b + offset).value or 0
+            if not val_a or not val_b or val_a == val_b:
+                continue
+            if is_valid_handle(val_a) and is_valid_handle(val_b):
+                return offset
+        return -1
+
+    def test_finds_differing_field(self):
+        """Two structs with same layout, different values at one field."""
+        ptr_size = sizeof(c_void_p)
+        # Struct: [same, same, DIFFERENT, same]
+        buf_a = _make_fake_struct([100, 200, 0xABCD, 400])
+        buf_b = _make_fake_struct([100, 200, 0xDCBA, 400])
+        valid = {0xABCD, 0xDCBA}
+        offset = self._scan_for_differing_valid_handles(
+            addressof(buf_a), addressof(buf_b),
+            len(buf_a), lambda v: v in valid,
+        )
+        self.assertEqual(offset, 2 * ptr_size)
+
+    def test_skips_same_values(self):
+        """Fields with identical values are skipped."""
+        buf_a = _make_fake_struct([100, 200, 300])
+        buf_b = _make_fake_struct([100, 200, 300])
+        offset = self._scan_for_differing_valid_handles(
+            addressof(buf_a), addressof(buf_b),
+            len(buf_a), lambda v: True,
+        )
+        self.assertEqual(offset, -1)
+
+    def test_skips_zero_values(self):
+        """Fields with zero values are skipped even if they differ."""
+        buf_a = _make_fake_struct([0, 200])
+        buf_b = _make_fake_struct([100, 200])
+        offset = self._scan_for_differing_valid_handles(
+            addressof(buf_a), addressof(buf_b),
+            len(buf_a), lambda v: True,
+        )
+        # First field: val_a=0, skipped. Second field: same. No match.
+        self.assertEqual(offset, -1)
+
+    def test_skips_invalid_handles(self):
+        """Fields that differ but fail validation are skipped."""
+        buf_a = _make_fake_struct([0xAAAA, 0xBBBB])
+        buf_b = _make_fake_struct([0xCCCC, 0xDDDD])
+        valid = {0xBBBB, 0xDDDD}
+        ptr_size = sizeof(c_void_p)
+        offset = self._scan_for_differing_valid_handles(
+            addressof(buf_a), addressof(buf_b),
+            len(buf_a), lambda v: v in valid,
+        )
+        self.assertEqual(offset, 1 * ptr_size)
+
+    def test_first_valid_match_wins(self):
+        """When multiple fields differ and validate, the first offset wins."""
+        buf_a = _make_fake_struct([0x1111, 0x3333])
+        buf_b = _make_fake_struct([0x2222, 0x4444])
+        ptr_size = sizeof(c_void_p)
+        offset = self._scan_for_differing_valid_handles(
+            addressof(buf_a), addressof(buf_b),
+            len(buf_a), lambda v: True,
+        )
+        self.assertEqual(offset, 0)
+
+
+@unittest.skipUnless(WIN32, "Win32-only: requires GDK Win32 backend")
+class TestHCursorProbeWin32(unittest.TestCase):
+    """End-to-end tests that run on Win32 with a real GDK display."""
+
+    def test_probe_finds_offset(self):
+        """The probe should discover a non-negative offset."""
+        from xpra.platform.win32.gui import _probe_hcursor_offset
+        offset = _probe_hcursor_offset()
+        self.assertGreaterEqual(offset, 0, "probe failed to find HCURSOR offset")
+        # Offset should be reasonable (within typical GObject struct sizes)
+        self.assertLess(offset, 256)
+
+    def test_extract_hcursor_from_arrow(self):
+        """Extracting HCURSOR from an arrow cursor should return non-zero."""
+        from xpra.platform.win32.gui import _get_hcursor_from_gdk_cursor
+        from xpra.os_util import gi_import
+        Gdk = gi_import("Gdk")
+        display = Gdk.Display.get_default()
+        if not display:
+            self.skipTest("no display")
+        cursor = Gdk.Cursor.new_for_display(display, Gdk.CursorType.ARROW)
+        hcursor = _get_hcursor_from_gdk_cursor(cursor)
+        self.assertNotEqual(hcursor, 0, "failed to extract HCURSOR from arrow cursor")
+
+    def test_extract_hcursor_different_types(self):
+        """Different cursor types should yield different HCURSOR values."""
+        from xpra.platform.win32.gui import _get_hcursor_from_gdk_cursor
+        from xpra.os_util import gi_import
+        Gdk = gi_import("Gdk")
+        display = Gdk.Display.get_default()
+        if not display:
+            self.skipTest("no display")
+        arrow = Gdk.Cursor.new_for_display(display, Gdk.CursorType.ARROW)
+        cross = Gdk.Cursor.new_for_display(display, Gdk.CursorType.CROSSHAIR)
+        h_arrow = _get_hcursor_from_gdk_cursor(arrow)
+        h_cross = _get_hcursor_from_gdk_cursor(cross)
+        self.assertNotEqual(h_arrow, 0)
+        self.assertNotEqual(h_cross, 0)
+        self.assertNotEqual(h_arrow, h_cross,
+                            "arrow and crosshair should have different HCURSOR handles")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/xpra/client/gtk3/client_base.py
+++ b/xpra/client/gtk3/client_base.py
@@ -943,7 +943,9 @@ class GTKXpraClient(GObjectClientAdapter, UIXpraClient):
             # trays don't have a gdk window
             if gdkwin:
                 self._cursors[w] = cursor_data
-                gdkwin.set_cursor(cursor)
+                update_fn = getattr(w, "_update_cursor_subclass", None)
+                if update_fn is None or not update_fn(cursor):
+                    gdkwin.set_cursor(cursor)
 
     def make_cursor(self, cursor_data: Sequence) -> Gdk.Cursor | None:
         # if present, try cursor ny name:

--- a/xpra/client/gtk3/opengl/client_window.py
+++ b/xpra/client/gtk3/opengl/client_window.py
@@ -6,6 +6,7 @@
 
 from xpra.client.gtk3.window.window import ClientWindow
 from xpra.gtk.window import set_visual
+from xpra.platform.gui import setup_gl_drawing_area, cleanup_gl_drawing_area
 from xpra.util.objects import typedict
 from xpra.util.env import envbool
 from xpra.log import Logger
@@ -87,6 +88,7 @@ class GLClientWindowBase(ClientWindow):
         self._backing.paint_screen = True
 
     def destroy(self) -> None:
+        cleanup_gl_drawing_area(self)
         self.remove_backing()
         super().destroy()
 
@@ -94,6 +96,7 @@ class GLClientWindowBase(ClientWindow):
         self.drawing_area = None
 
     def new_backing(self, bw: int, bh: int) -> None:
+        cleanup_gl_drawing_area(self)
         widget = super().new_backing(bw, bh)
         if self.drawing_area:
             self.remove(self.drawing_area)
@@ -107,6 +110,7 @@ class GLClientWindowBase(ClientWindow):
             self.drawing_area.set_size_request(*minsize)
         self.add(widget)
         self.drawing_area = widget
+        setup_gl_drawing_area(self, widget)
         # maybe redundant?:
         self.apply_geometry_hints(self.geometry_hints)
 

--- a/xpra/platform/gui.py
+++ b/xpra/platform/gui.py
@@ -264,6 +264,19 @@ def remove_window_hooks(_window) -> None:
     """
 
 
+def setup_gl_drawing_area(_window, _widget) -> None:
+    """
+    Platform-specific setup for GL DrawingArea cursor handling.
+    On Win32, installs an HWND subclass to apply the correct cursor.
+    """
+
+
+def cleanup_gl_drawing_area(_window) -> None:
+    """
+    Remove platform-specific GL DrawingArea cursor handling.
+    """
+
+
 def show_desktop(_show) -> None:
     """ If possible, show the desktop """
 
@@ -384,6 +397,7 @@ platform_import(globals(), "gui", False,
                 "get_fixed_cursor_size", "get_default_cursor_size", "get_max_cursor_size",
                 "get_window_frame_sizes",
                 "add_window_hooks", "remove_window_hooks",
+                "setup_gl_drawing_area", "cleanup_gl_drawing_area",
                 "system_bell",
                 "get_display_name",
                 "get_display_size",

--- a/xpra/platform/win32/gui.py
+++ b/xpra/platform/win32/gui.py
@@ -8,7 +8,6 @@
 # Platform-specific code for Win32 -- the parts that may import gtk.
 
 import os
-import re
 import sys
 import types
 from typing import Any
@@ -642,41 +641,99 @@ def remove_window_hooks(window) -> None:
 # comctl32 SetWindowSubclass to intercept WM_SETCURSOR and call SetCursor
 # with the correct HCURSOR ourselves.
 
-# GdkWin32Cursor.__repr__ returns e.g. "<GdkWin32Cursor at 0x1a2b3c4d5e6f)"
-# We extract the C struct address to read the HCURSOR field directly.
-_HCURSOR_PATTERN = re.compile(r"GdkWin32Cursor at (0x[0-9a-fA-F]+)\)")
+# GDK's GdkWin32Cursor struct stores the Win32 HCURSOR handle, but
+# there's no public accessor function. We find the field offset at
+# runtime by probing: create two cursors of different types, get their
+# C struct pointers, and find the pointer-aligned offset where both
+# contain different values that are valid cursor handles (verified by
+# GetIconInfo). This avoids hardcoded offsets and works regardless of
+# cursor themes or struct layout changes.
+_HCURSOR_OFFSET = None  # discovered at runtime by _probe_hcursor_offset()
 
-# Byte offset of the HCURSOR field within the GdkWin32Cursor C struct.
-# Layout: GObject(24) + display*(8) + cursor_type(4)+pad(4) + name*(8) + HCURSOR(8)
-# See: https://gitlab.gnome.org/GNOME/gtk/-/blob/gtk-3-24/gdk/win32/gdkprivate-win32.h
-# This is ABI-fragile: tied to GTK3's struct layout. GTK3 is in maintenance
-# mode (3.24.x final) so the layout is effectively frozen. If GTK4 is ever
-# used, this offset will be wrong — GTK4 uses a different cursor API entirely.
-# On failure, get_hcursor_from_gdk_cursor returns 0 and the subclass is not installed.
-_GDKWIN32CURSOR_HCURSOR_OFFSET = 48
 
-# Win32 message constants for the subclass proc
-_WM_SETCURSOR = 0x0020
-_WM_NCDESTROY = 0x0082
-_HTCLIENT = 1
+def _probe_hcursor_offset() -> int:
+    """Discover the HCURSOR field offset in GdkWin32Cursor by creating two
+    probe cursors and finding where their struct contents differ by a
+    valid cursor handle.
+
+    Returns the byte offset, or -1 if the probe fails."""
+    from gi.repository import GObject as GObjectLib
+    from xpra.platform.win32.common import GetIconInfo, ICONINFO, DeleteObject
+
+    display = Gdk.Display.get_default()
+    if not display:
+        cursorlog("_probe_hcursor_offset: no display")
+        return -1
+
+    # Create two cursors of different types — their HCURSOR handles will
+    # differ, letting us identify which struct field holds the handle.
+    cursor_a = Gdk.Cursor.new_for_display(display, Gdk.CursorType.ARROW)
+    cursor_b = Gdk.Cursor.new_for_display(display, Gdk.CursorType.CROSSHAIR)
+    if not cursor_a or not cursor_b:
+        cursorlog("_probe_hcursor_offset: failed to create probe cursors")
+        return -1
+
+    ptr_a = PyCapsule_GetPointer(cursor_a.__gpointer__, None)
+    ptr_b = PyCapsule_GetPointer(cursor_b.__gpointer__, None)
+
+    # Query the GType system for the exact struct size so we don't scan
+    # past the end of the allocation.
+    try:
+        query = GObjectLib.type_query(type(cursor_a).__gtype__)
+        scan_limit = query.instance_size
+        cursorlog("_probe_hcursor_offset: GdkWin32Cursor instance_size=%d", scan_limit)
+    except Exception as e:
+        cursorlog.warn("Warning: cannot query GdkWin32Cursor instance size: %s", e)
+        return -1
+
+    ptr_size = sizeof(c_void_p)
+    for offset in range(0, scan_limit, ptr_size):
+        val_a = c_void_p.from_address(ptr_a + offset).value or 0
+        val_b = c_void_p.from_address(ptr_b + offset).value or 0
+        if not val_a or not val_b or val_a == val_b:
+            continue
+        # Both non-zero and different — check if they're valid cursor handles
+        info = ICONINFO()
+        if GetIconInfo(val_a, byref(info)):
+            # Clean up bitmaps returned by GetIconInfo
+            if info.hbmMask:
+                DeleteObject(info.hbmMask)
+            if info.hbmColor:
+                DeleteObject(info.hbmColor)
+            info2 = ICONINFO()
+            if GetIconInfo(val_b, byref(info2)):
+                if info2.hbmMask:
+                    DeleteObject(info2.hbmMask)
+                if info2.hbmColor:
+                    DeleteObject(info2.hbmColor)
+                cursorlog("_probe_hcursor_offset: found HCURSOR at offset %d "
+                          "(probe_a=%s, probe_b=%s)", offset, hex(val_a), hex(val_b))
+                return offset
+    cursorlog.warn("Warning: failed to discover HCURSOR offset in GdkWin32Cursor")
+    return -1
+
+# Unique ID for our SetWindowSubclass registration. The comctl32 subclass
+# API uses this to distinguish multiple subclasses on the same HWND.
+# Arbitrary value; just needs to be unique within this process.
 _GL_CURSOR_SUBCLASS_ID = 0xAC01
 
 
 def _get_hcursor_from_gdk_cursor(cursor) -> int:
-    """Extract the Win32 HCURSOR handle from a GdkWin32Cursor's C struct."""
-    m = _HCURSOR_PATTERN.search(repr(cursor))
-    if not m:
-        cursorlog.warn("Warning: cannot parse GdkWin32Cursor repr: %s", repr(cursor)[:80])
+    """Extract the Win32 HCURSOR handle from a GdkCursor's C struct
+    using the runtime-discovered field offset."""
+    global _HCURSOR_OFFSET
+    if _HCURSOR_OFFSET is None:
+        _HCURSOR_OFFSET = _probe_hcursor_offset()
+    if _HCURSOR_OFFSET < 0:
         return 0
-    c_ptr = int(m.group(1), 16)
     try:
-        val = c_void_p.from_address(c_ptr + _GDKWIN32CURSOR_HCURSOR_OFFSET).value or 0
-        cursorlog("extracted HCURSOR=%s from GdkWin32Cursor struct at %s",
-                  hex(val) if val else 0, hex(c_ptr))
-        return val
+        gpointer = PyCapsule_GetPointer(cursor.__gpointer__, None)
+        hcursor = c_void_p.from_address(gpointer + _HCURSOR_OFFSET).value or 0
+        cursorlog("extracted HCURSOR=%s from GdkCursor at offset %d",
+                  hex(hcursor) if hcursor else 0, _HCURSOR_OFFSET)
+        return hcursor
     except Exception as e:
-        cursorlog.warn("Warning: failed reading HCURSOR at offset %d: %s",
-                       _GDKWIN32CURSOR_HCURSOR_OFFSET, e)
+        cursorlog.warn("Warning: failed to extract HCURSOR: %s", e)
         return 0
 
 
@@ -702,12 +759,12 @@ def _install_gl_cursor_subclass(window, hwnd: int, hcursor: int) -> None:
     @SUBCLASSPROC
     def subclass_proc(h, msg, wparam, lparam, uid, ref_data):
         try:
-            if msg == _WM_SETCURSOR and (lparam & 0xFFFF) == _HTCLIENT:
+            if msg == win32con.WM_SETCURSOR and (lparam & 0xFFFF) == win32con.HTCLIENT:  # LOWORD = hit-test
                 hc = hcursor_holder[0]
                 if hc:
                     SetCursor(c_void_p(hc))
                     return 1  # handled — prevents DefWindowProc from setting arrow
-            if msg == _WM_NCDESTROY:
+            if msg == win32con.WM_NCDESTROY:
                 RemoveWindowSubclass(h, subclass_proc, _GL_CURSOR_SUBCLASS_ID)
                 window._gl_cursor_info = None
                 window._gl_cursor_holder = None

--- a/xpra/platform/win32/gui.py
+++ b/xpra/platform/win32/gui.py
@@ -1,19 +1,21 @@
 # This file is part of Xpra.
 # Copyright (C) 2010 Nathaniel Smith <njs@pobox.com>
 # Copyright (C) 2011 Antoine Martin <antoine@xpra.org>
+# Copyright (C) 2026 Netflix, Inc.
 # Xpra is released under the terms of the GNU GPL v2, or, at your option, any
 # later version. See the file COPYING for details.
 
 # Platform-specific code for Win32 -- the parts that may import gtk.
 
 import os
+import re
 import sys
 import types
 from typing import Any
 from collections.abc import Callable, Sequence
 from ctypes import (
     WinDLL,  # @UnresolvedImport
-    CDLL, pythonapi, py_object,
+    CDLL, pythonapi, py_object, c_void_p,
     HRESULT, c_bool, create_string_buffer, byref, addressof, sizeof,  # @UnresolvedImport
 )
 from ctypes.wintypes import HWND, DWORD, POINT, RECT, HGDIOBJ, LPCWSTR
@@ -34,6 +36,8 @@ from xpra.platform.win32.common import (
     GetIntSystemParametersInfo,
     GetUserObjectInformationA, OpenInputDesktop, CloseDesktop,
     GetMonitorInfo,
+    SetCursor, SUBCLASSPROC,
+    SetWindowSubclass, RemoveWindowSubclass, DefSubclassProc,
 )
 from xpra.os_util import gi_import
 from xpra.util.objects import typedict
@@ -47,8 +51,10 @@ grablog = Logger("win32", "grab")
 screenlog = Logger("win32", "screen")
 keylog = Logger("win32", "keyboard")
 pointerlog = Logger("win32", "pointer")
+cursorlog = Logger("win32", "cursor")
 
 GLib = gi_import("GLib")
+Gdk = gi_import("Gdk")
 
 REINIT_VISIBLE_WINDOWS = envbool("XPRA_WIN32_REINIT_VISIBLE_WINDOWS", True)
 APP_ID = os.environ.get("XPRA_WIN32_APP_ID", "Xpra")
@@ -626,6 +632,200 @@ def remove_window_hooks(window) -> None:
             window.win32hooks = None
     except Exception:
         log.error("remove_window_hooks(%s)", exc_info=True)
+
+
+# ---- GL DrawingArea cursor subclass ----
+#
+# On Win32, GL windows have a separate child HWND for the DrawingArea.
+# GDK's WM_SETCURSOR handler doesn't apply the cursor to this child HWND,
+# so it always shows the arrow cursor. We subclass the child HWND via
+# comctl32 SetWindowSubclass to intercept WM_SETCURSOR and call SetCursor
+# with the correct HCURSOR ourselves.
+
+# GdkWin32Cursor.__repr__ returns e.g. "<GdkWin32Cursor at 0x1a2b3c4d5e6f)"
+# We extract the C struct address to read the HCURSOR field directly.
+_HCURSOR_PATTERN = re.compile(r"GdkWin32Cursor at (0x[0-9a-fA-F]+)\)")
+
+# Byte offset of the HCURSOR field within the GdkWin32Cursor C struct.
+# Layout: GObject(24) + display*(8) + cursor_type(4)+pad(4) + name*(8) + HCURSOR(8)
+# See: https://gitlab.gnome.org/GNOME/gtk/-/blob/gtk-3-24/gdk/win32/gdkprivate-win32.h
+# This is ABI-fragile: tied to GTK3's struct layout. GTK3 is in maintenance
+# mode (3.24.x final) so the layout is effectively frozen. If GTK4 is ever
+# used, this offset will be wrong — GTK4 uses a different cursor API entirely.
+# On failure, get_hcursor_from_gdk_cursor returns 0 and the subclass is not installed.
+_GDKWIN32CURSOR_HCURSOR_OFFSET = 48
+
+# Win32 message constants for the subclass proc
+_WM_SETCURSOR = 0x0020
+_WM_NCDESTROY = 0x0082
+_HTCLIENT = 1
+_GL_CURSOR_SUBCLASS_ID = 0xAC01
+
+
+def _get_hcursor_from_gdk_cursor(cursor) -> int:
+    """Extract the Win32 HCURSOR handle from a GdkWin32Cursor's C struct."""
+    m = _HCURSOR_PATTERN.search(repr(cursor))
+    if not m:
+        cursorlog.warn("Warning: cannot parse GdkWin32Cursor repr: %s", repr(cursor)[:80])
+        return 0
+    c_ptr = int(m.group(1), 16)
+    try:
+        val = c_void_p.from_address(c_ptr + _GDKWIN32CURSOR_HCURSOR_OFFSET).value or 0
+        cursorlog("extracted HCURSOR=%s from GdkWin32Cursor struct at %s",
+                  hex(val) if val else 0, hex(c_ptr))
+        return val
+    except Exception as e:
+        cursorlog.warn("Warning: failed reading HCURSOR at offset %d: %s",
+                       _GDKWIN32CURSOR_HCURSOR_OFFSET, e)
+        return 0
+
+
+def _install_gl_cursor_subclass(window, hwnd: int, hcursor: int) -> None:
+    """Subclass an HWND to intercept WM_SETCURSOR and apply our cursor.
+    Uses SetWindowSubclass (comctl32) which is safe and chainable."""
+    existing = getattr(window, "_gl_cursor_info", None)
+    if existing and existing[0] == hwnd:
+        # Already subclassed this HWND — just update the cursor handle
+        window._gl_cursor_holder[0] = hcursor
+        cursorlog("updated HCURSOR=%s on existing subclass hwnd=%s wid=%#x",
+                  hex(hcursor) if hcursor else 0, hex(hwnd), window.wid)
+        return
+
+    _remove_gl_cursor_subclass(window)
+
+    # Mutable holder so we can update HCURSOR without re-subclassing
+    hcursor_holder = [hcursor]
+    window._gl_cursor_holder = hcursor_holder
+
+    wid = window.wid
+
+    @SUBCLASSPROC
+    def subclass_proc(h, msg, wparam, lparam, uid, ref_data):
+        try:
+            if msg == _WM_SETCURSOR and (lparam & 0xFFFF) == _HTCLIENT:
+                hc = hcursor_holder[0]
+                if hc:
+                    SetCursor(c_void_p(hc))
+                    return 1  # handled — prevents DefWindowProc from setting arrow
+            if msg == _WM_NCDESTROY:
+                RemoveWindowSubclass(h, subclass_proc, _GL_CURSOR_SUBCLASS_ID)
+                window._gl_cursor_info = None
+                window._gl_cursor_holder = None
+                cursorlog("gl cursor subclass removed on WM_NCDESTROY wid=%#x", wid)
+        except Exception as e:
+            cursorlog.warn("Warning: gl cursor subclass error: %s", e)
+        return DefSubclassProc(h, msg, wparam, lparam)
+
+    result = SetWindowSubclass(hwnd, subclass_proc, _GL_CURSOR_SUBCLASS_ID, 0)
+    if result:
+        # Store strong references to prevent GC of the callback
+        window._gl_cursor_info = (hwnd, subclass_proc, _GL_CURSOR_SUBCLASS_ID)
+        cursorlog("installed gl cursor subclass on hwnd=%s hcursor=%s wid=%#x",
+                  hex(hwnd), hex(hcursor) if hcursor else 0, window.wid)
+    else:
+        cursorlog.warn("Warning: SetWindowSubclass failed for hwnd=%s wid=%#x",
+                       hex(hwnd), window.wid)
+        window._gl_cursor_holder = None
+
+
+def _remove_gl_cursor_subclass(window) -> None:
+    """Remove the cursor subclass if installed."""
+    info = getattr(window, "_gl_cursor_info", None)
+    if not info:
+        return
+    hwnd, callback, subclass_id = info
+    window._gl_cursor_info = None
+    window._gl_cursor_holder = None
+    window._gl_cursor_ref = None
+    try:
+        RemoveWindowSubclass(hwnd, callback, subclass_id)
+        cursorlog("removed gl cursor subclass from hwnd=%s wid=%#x", hex(hwnd), window.wid)
+    except Exception as e:
+        cursorlog.warn("Warning: RemoveWindowSubclass failed: %s", e)
+
+
+def _update_gl_cursor(window, cursor) -> bool:
+    """Called from set_windows_cursor when a cursor update arrives.
+    Updates the HCURSOR holder so the subclass applies the new cursor on
+    the next WM_SETCURSOR without needing to re-subclass the HWND.
+    Always returns False so the caller also calls gdkwin.set_cursor() —
+    GDK needs the cursor stored on the parent HWND for drag scenarios
+    where WM_SETCURSOR goes to the parent instead of the child."""
+    info = getattr(window, "_gl_cursor_info", None)
+    if not info:
+        return False
+    holder = getattr(window, "_gl_cursor_holder", None)
+    if holder is None:
+        return False
+    if not cursor:
+        holder[0] = 0
+        window._gl_cursor_ref = None
+        return False
+    hcursor = _get_hcursor_from_gdk_cursor(cursor)
+    if hcursor:
+        holder[0] = hcursor
+        window._gl_cursor_ref = cursor  # prevent GC of Win32 HCURSOR
+    else:
+        holder[0] = 0
+        window._gl_cursor_ref = None
+    return False
+
+
+def setup_gl_drawing_area(window, widget) -> None:
+    """Install Win32 cursor handling for a GL DrawingArea widget.
+    Connects to the widget's realize signal to subclass the child HWND."""
+    cursorlog("setup_gl_drawing_area(%s, %s) wid=%#x", window, widget, window.wid)
+
+    def on_realize(w):
+        hwnd = get_window_handle(w)
+        cursorlog("gl drawing area realized: widget=%s, hwnd=%s, wid=%#x",
+                  w, hex(hwnd) if hwnd else 0, window.wid)
+        if not hwnd:
+            cursorlog.warn("Warning: GL DrawingArea has no HWND, cursor subclass not installed")
+            return
+
+        # Check if parent window has a different HWND (for diagnostics)
+        parent_hwnd = get_window_handle(window)
+        cursorlog("gl cursor: parent_hwnd=%s, child_hwnd=%s, same=%s",
+                  hex(parent_hwnd) if parent_hwnd else 0,
+                  hex(hwnd),
+                  parent_hwnd == hwnd)
+
+        # Check if GDK already has a cursor set on this widget
+        gdkwin = w.get_window()
+        existing_cursor = gdkwin.get_cursor() if gdkwin else None
+        hcursor = 0
+        if existing_cursor:
+            hcursor = _get_hcursor_from_gdk_cursor(existing_cursor)
+            cursorlog("gl cursor: existing GDK cursor=%s, hcursor=%s",
+                      existing_cursor, hex(hcursor) if hcursor else 0)
+
+        _install_gl_cursor_subclass(window, hwnd, hcursor)
+
+        # Attach _update_cursor_subclass method for duck-typing by set_windows_cursor
+        window._update_cursor_subclass = lambda cursor: _update_gl_cursor(window, cursor)
+        cursorlog("gl cursor: attached _update_cursor_subclass to window wid=%#x", window.wid)
+
+    def on_enter(_w, _event=None):
+        # Apply cursor immediately when mouse enters the DrawingArea,
+        # so there's no flicker before the next WM_SETCURSOR message.
+        holder = getattr(window, "_gl_cursor_holder", None)
+        if holder and holder[0]:
+            SetCursor(c_void_p(holder[0]))
+            cursorlog("gl cursor: SetCursor on enter-notify, hcursor=%s wid=%#x",
+                      hex(holder[0]), window.wid)
+
+    widget.connect("realize", on_realize)
+    widget.add_events(Gdk.EventMask.ENTER_NOTIFY_MASK)
+    widget.connect_after("enter-notify-event", on_enter)
+
+
+def cleanup_gl_drawing_area(window) -> None:
+    """Remove the GL DrawingArea cursor subclass."""
+    _remove_gl_cursor_subclass(window)
+    # Clean up the duck-type method
+    if hasattr(window, "_update_cursor_subclass"):
+        del window._update_cursor_subclass
 
 
 def get_xdpi() -> int:


### PR DESCRIPTION
## Problem

On Win32, GL windows have a child HWND for the DrawingArea whose WM_SETCURSOR handler resets the cursor to the default arrow on every mouse move. `gdkwin.set_cursor()` sets the cursor on the GDK window, but the child HWND's WM_SETCURSOR immediately overrides it.

This means the cursor cache fix (#4822) alone is not sufficient for GL windows — it applies the cursor via `gdkwin.set_cursor()`, which is overridden by the child HWND on the next mouse move. Cairo windows don't have this problem because GDK handles `WM_SETCURSOR` correctly on their HWNDs.

### Why subclassing is necessary

Two simpler alternatives were tested and both fail (see [test results comment](https://github.com/Xpra-org/xpra/pull/4824#issuecomment-4113255328)):

- **SetClassLongPtrW with actual HCURSOR** (Option 1): Class cursor IS updated (logs confirm), but the child HWND's WndProc handles WM_SETCURSOR directly before DefWindowProc ever sees it. Changing GCLP_HCURSOR has no effect.
- **Null class cursor to bubble WM_SETCURSOR** (Option 2): GCLP_HCURSOR is per-class and shared across all GL windows. Nulling it causes cursor to disappear entirely.

Both alternatives assume DefWindowProc handles WM_SETCURSOR, which testing proves is wrong. The comctl32 `SetWindowSubclass` approach works because it inserts our handler *before* the original WndProc.

## Solution

Subclass the GL DrawingArea's child HWND via comctl32 `SetWindowSubclass` to intercept `WM_SETCURSOR` and call `SetCursor` with the correct `HCURSOR`.

All Win32 code lives in `xpra.platform.win32.gui` — `GLClientWindowBase` remains completely platform-agnostic, calling only `setup_gl_drawing_area`/`cleanup_gl_drawing_area` from `xpra.platform.gui`.

### Changes

- `platform/gui.py`: no-op stubs + `platform_import`
- `platform/win32/gui.py`: HCURSOR extraction, HWND subclass, realize/enter-notify handlers
- `client/gtk3/opengl/client_window.py`: two platform calls (`setup_gl_drawing_area`/`cleanup_gl_drawing_area`)
- `client/gtk3/client_base.py`: `_update_cursor_subclass` duck-typing in `set_windows_cursor`

Supersedes #4815.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Sponsored-by: Netflix