### PR TITLE
fix OR window geometry race on setup

### DIFF
--- a/xpra/x11/models/or_window.py
+++ b/xpra/x11/models/or_window.py
@@ -1,3 +1,5 @@
+# ABOUTME: Override-redirect window model for unmanaged (OR) X11 windows.
+# ABOUTME: Re-reads geometry after event subscription to catch races with fast-resizing windows.
 # This file is part of Xpra.
 # Copyright (C) 2008 Nathaniel Smith <njs@pobox.com>
 # Copyright (C) 2011 Antoine Martin <antoine@xpra.org>
@@ -8,10 +10,13 @@ from xpra.os_util import gi_import
 from xpra.x11.common import Unmanageable
 from xpra.x11.models.base import BaseWindowModel
 from xpra.x11.bindings.window import X11WindowBindings
+from xpra.log import Logger
 
 X11Window = X11WindowBindings()
 
 GObject = gi_import("GObject")
+
+geomlog = Logger("x11", "window", "geometry")
 
 
 class OverrideRedirectWindowModel(BaseWindowModel):
@@ -43,6 +48,24 @@ class OverrideRedirectWindowModel(BaseWindowModel):
         ch = self._composite.get_contents_handle()
         if ch is None:
             raise Unmanageable("failed to get damage handle")
+        # Re-read geometry now that StructureNotifyMask is set (from super().setup()).
+        # The window may have resized between __init__ reading the initial geometry
+        # and setup() subscribing to events — any ConfigureNotify from that gap is lost.
+        self._recheck_geometry()
+
+    def _recheck_geometry(self) -> None:
+        try:
+            actual = X11Window.getGeometry(self.xid)
+        except Exception:
+            return
+        if not actual:
+            return
+        actual_geom = actual[:4]
+        model_geom = self._gproperties.get("geometry")
+        if model_geom and model_geom != actual_geom:
+            geomlog.info("OR window %#x geometry changed during setup: %s -> %s",
+                        self.xid, model_geom, actual_geom)
+            self._updateprop("geometry", actual_geom)
 
 
 GObject.type_register(OverrideRedirectWindowModel)


### PR DESCRIPTION
## Summary
- Override-redirect windows can resize between model `__init__` (which reads the initial geometry) and `setup()` (which subscribes to `StructureNotifyMask`). Any `ConfigureNotify` generated in that gap is lost, leaving the server model with stale geometry and the client window stuck at its initial size.
- Re-reads the actual X11 geometry after `setup()` completes and updates the model if it changed.

## Symptoms
- IntelliJ's Search Everywhere dialog (Ctrl+Shift+N) intermittently stays as a skinny search bar instead of expanding to show results
- Also observed with code completion dropdowns
- Both are `JWindow`-based override-redirect windows that open small then immediately resize — the resize consistently completes before xpra finishes subscribing to events

## Diagnosis
- `xpra info` showed the server model stuck at the initial small geometry (e.g. 672x60) while `xwininfo` showed the actual X11 window had already resized (e.g. 674x651)
- Adding a periodic geometry checker confirmed the model was stale and that `ConfigureNotify` events either arrived very late or never arrived at all
- Root cause: the window resizes during the gap between `CoreX11WindowModel.__init__` reading the initial geometry and `setup()` calling `addDefaultEvents()` to subscribe to `StructureNotifyMask`

🤖 Generated with [Claude Code](https://claude.com/claude-code)