### PR TITLE
Backup subcommand writes to truncated filename instead of config path

### DIFF
--- a/xpra/gtk/configure/main.py
+++ b/xpra/gtk/configure/main.py
@@ -30,7 +30,7 @@ def main(args=()) -> ExitValue:
             if not os.path.exists(conf):
                 print(f"# {conf!r} does not exist yet")
                 return ExitCode.FILE_NOT_FOUND
-            bak = conf[-5:]+".bak"
+            bak = conf+".bak"
             with open(conf, "r", encoding="utf8") as read:
                 with open(bak, "w", encoding="utf8") as write:
                     write.write(read.read())


### PR DESCRIPTION
## Summary

The backup filename is computed as `conf[-5:] + ".bak"`, which uses only the last 5 characters of the config path. This causes backups to be written to an unrelated relative file (often in current working directory), potentially overwriting wrong files and silently failing to back up the real config.

## Files changed

- `xpra/gtk/configure/main.py` (modified)

## Testing

- Not run in this environment.


Closes #4838