### PR TITLE
Add robust fallback path when loading `.xpm` icons fails in Pillow

### DIFF
--- a/xpra/platform/posix/menu_helper.py
+++ b/xpra/platform/posix/menu_helper.py
@@ -90,7 +90,11 @@ def export(entry, properties: Sequence[str]) -> dict[str, Any]:
             log_fn("error on %s", entry, exc_info=True)
             log.error(f"Error parsing {prop!r}: {e}")
     log_fn(f"properties({name})={props}")
-    load_entry_icon(props)
+    try:
+        load_entry_icon(props)
+    except KeyError as e:
+        log("load_entry_icon(%s)", props, exc_info=True)
+        log.warn(f"Warning: failed to load icon: {e}")
     return props
 
 


### PR DESCRIPTION
## Summary

The current icon-loading path relies on `PIL.Image.open(...).load()`, which now fails on some valid-but-edge-case XPM files (example: Eclipse icon) with `KeyError: b'  '` from `PIL.XpmImagePlugin`. This breaks menu/icon discovery on Linux when desktop entries reference those icons.

## Files changed

- `xpra/platform/posix/menu_helper.py` (modified)

## Testing

- Not run in this environment.


Closes #4805