### PR TITLE
Fix benchmark_scaling.py on Windows (freeze support + WGL context)

### DIFF
--- a/tests/scripts/benchmark_scaling.py
+++ b/tests/scripts/benchmark_scaling.py
@@ -1126,7 +1126,15 @@ def main():
         elif gl_major < 3 or (gl_major == 3 and gl_minor < 3):
             print(f"OpenGL {gl_version_str} ({gl_renderer}) is below 3.3, skipping GPU benchmarks")
         else:
-            have_gl = True
+            # Shaders use #version 330 core — verify we have a core profile context
+            from OpenGL.GL import glGetIntegerv, GL_CONTEXT_PROFILE_MASK
+            GL_CONTEXT_CORE_PROFILE_BIT = 0x00000001
+            profile = glGetIntegerv(GL_CONTEXT_PROFILE_MASK)
+            if not (profile & GL_CONTEXT_CORE_PROFILE_BIT):
+                print(f"OpenGL {gl_version_str} ({gl_renderer}) is compatibility profile,")
+                print(f"  skipping GPU benchmarks (shaders require core profile)")
+            else:
+                have_gl = True
     except Exception as e:
         print(f"OpenGL not available ({e}), skipping GPU benchmarks")
 


### PR DESCRIPTION
## Summary

Three fixes for `benchmark_scaling.py` on Windows:

- **Frozen build crash:** Add `multiprocessing.freeze_support()` before `main()` — without this, cx_Freeze builds crash because the child process re-invokes the EXE with `--multiprocessing-fork` arguments that argparse rejects

- **GDI Generic on x64:** The legacy `wglCreateContext` returns a GDI Generic (GL 1.1) software renderer on x64 Windows, crashing when the benchmark tries to use GL 3.3 features. Use the standard [two-phase WGL bootstrap](https://www.khronos.org/opengl/wiki/Creating_an_OpenGL_Context_(WGL)) per the Khronos spec: create a throwaway context to load `wglChoosePixelFormatARB` and `wglCreateContextAttribsARB`, then request a hardware-accelerated GL 3.3 core profile context on a fresh window. Falls back to the legacy path on ARM64 where it already works. This only affects the benchmark because it creates a minimal hidden window via raw Win32 API; xpra itself creates GL contexts on GDK-managed windows where the GPU driver engages normally.

- **GL capability validation:** After context creation, validate renderer (not GDI Generic), GL version (>= 3.3), and profile (core, not compatibility) before running GPU benchmarks. Prints a specific diagnostic instead of crashing.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Sponsored-By: Netflix