### PR TITLE
Fix GL window bleed-through on Win32 with Intel GPUs

### DIFF
--- a/xpra/client/gtk3/opengl/client_window.py
+++ b/xpra/client/gtk3/opengl/client_window.py
@@ -97,7 +97,14 @@ class GLClientWindowBase(ClientWindow):
         widget = super().new_backing(bw, bh)
         if self.drawing_area:
             self.remove(self.drawing_area)
-        set_visual(widget, self._has_alpha)
+        # On Intel Win32, force RGBA visual so the GDI surface has a proper
+        # alpha channel (Intel's pixel format has alpha bits even when none
+        # are requested, and DWM reads undefined alpha as transparent).
+        # _is_intel is None before detection, so `or False` ensures a clean bool.
+        from xpra.os_util import WIN32
+        from xpra.opengl.backing import GLWindowBackingBase
+        intel = WIN32 and (GLWindowBackingBase._is_intel or False)
+        set_visual(widget, self._has_alpha or intel)
         widget.show()
         self.init_widget_events(widget)
         if self.drawing_area and self.size_constraints:

--- a/xpra/client/gtk3/opengl/drawing_area.py
+++ b/xpra/client/gtk3/opengl/drawing_area.py
@@ -37,6 +37,7 @@ class GLDrawingArea(GLWindowBackingBase):
 
     def init_backing(self) -> None:
         da = Gtk.DrawingArea()
+        da.set_app_paintable(True)
         da.connect_after("realize", self.on_realize)
         # da.connect('configure_event', self.on_configure_event)
         # da.connect('draw', self.on_draw)

--- a/xpra/client/gtk3/opengl/glarea_backing.py
+++ b/xpra/client/gtk3/opengl/glarea_backing.py
@@ -22,7 +22,13 @@ def GLArea(alpha: bool) -> Gtk.GLArea:
     glarea = Gtk.GLArea()
     glarea.set_use_es(True)
     glarea.set_auto_render(False)
-    glarea.set_has_alpha(alpha)
+    # On Intel Win32, force alpha in readback so the GDI surface gets
+    # alpha=255 (freedesktop.org bug #14165).
+    # _is_intel is None before detection, so `or False` ensures a clean bool.
+    from xpra.os_util import WIN32
+    from xpra.opengl.backing import GLWindowBackingBase
+    intel = WIN32 and (GLWindowBackingBase._is_intel or False)
+    glarea.set_has_alpha(alpha or intel)
     glarea.set_has_depth_buffer(False)
     glarea.set_has_stencil_buffer(False)
     glarea.set_required_version(3, 2)

--- a/xpra/opengl/backing.py
+++ b/xpra/opengl/backing.py
@@ -53,7 +53,7 @@ from OpenGL.GL.ARB.framebuffer_object import (
     glGenFramebuffers, glDeleteFramebuffers, glBindFramebuffer, glFramebufferTexture2D, glBlitFramebuffer,
 )
 
-from xpra.os_util import gi_import
+from xpra.os_util import WIN32, gi_import
 from xpra.util.str_fn import repr_ellipsized, hexstr, csv
 from xpra.util.env import envint, envbool, first_time
 from xpra.util.objects import typedict
@@ -247,6 +247,7 @@ class GLWindowBackingBase(WindowBackingBase):
         "RGB", "BGR",
     )
     HAS_ALPHA: bool = GL_ALPHA_SUPPORTED
+    _is_intel: bool | None = None  # cached across all windows
 
     def __init__(self, wid: int, window_alpha: bool, pixel_depth: int = 0):
         self.wid: int = wid
@@ -411,7 +412,7 @@ class GLWindowBackingBase(WindowBackingBase):
         if self._alpha_enabled:
             glClearColor(0, 0, 0, 1)
         else:
-            glClearColor(1, 1, 1, 0)
+            glClearColor(1, 1, 1, 1)
         glClear(GL_COLOR_BUFFER_BIT)
         # copy offscreen to new tmp:
         self.copy_fbo(w, h, sx, sy, dx, dy)
@@ -569,6 +570,13 @@ class GLWindowBackingBase(WindowBackingBase):
 
         if self.gl_setup:
             return
+        if GLWindowBackingBase._is_intel is None:
+            from OpenGL.GL import glGetString, GL_VENDOR
+            vendor = (glGetString(GL_VENDOR) or b"").decode("utf-8", "replace").lower()
+            GLWindowBackingBase._is_intel = "intel" in vendor
+            if WIN32 and GLWindowBackingBase._is_intel:
+                from xpra.platform.win32.gl_context import setup_intel_workarounds
+                setup_intel_workarounds(GLWindowBackingBase)
         mt = get_max_texture_size()
         w, h = self.size
         if w > mt or h > mt:
@@ -623,7 +631,7 @@ class GLWindowBackingBase(WindowBackingBase):
         if self._alpha_enabled:
             glClearColor(0, 0, 0, 1)
         else:
-            glClearColor(1, 1, 1, 0)
+            glClearColor(1, 1, 1, 1)
         glClear(GL_COLOR_BUFFER_BIT)
 
     def close_gl_config(self) -> None:
@@ -786,7 +794,7 @@ class GLWindowBackingBase(WindowBackingBase):
         if self._alpha_enabled:
             glClearColor(0, 0, 0, 1)
         else:
-            glClearColor(1, 1, 1, 0)
+            glClearColor(1, 1, 1, 1)
         glClear(GL_COLOR_BUFFER_BIT)
 
         glBlitFramebuffer(sx, sy, sx + w, sy + h,
@@ -845,6 +853,9 @@ class GLWindowBackingBase(WindowBackingBase):
             log.estr(e)
             log("Error presenting FBO", exc_info=True)
             self.last_present_fbo_error = str(e)
+
+    def _fixup_present_alpha(self) -> None:
+        """Platform hook for alpha fixups before present. Overridden on Win32+Intel."""
 
     def do_present_fbo(self, context) -> None:
         # the GL_DRAW_FRAMEBUFFER must already be set when calling this method
@@ -926,6 +937,8 @@ class GLWindowBackingBase(WindowBackingBase):
 
         if self.is_show_fps():
             self.draw_fps()
+
+        self._fixup_present_alpha()
 
         # Show the backbuffer on screen
         glFlush()

--- a/xpra/platform/win32/gl_context.py
+++ b/xpra/platform/win32/gl_context.py
@@ -238,6 +238,9 @@ class WGLContext:
             "double-buffered": bool(pfd.dwFlags & PFD_DOUBLEBUFFER)
         })
         log("DescribePixelFormat: %s", self.pixel_format_props)
+        if not self.alpha and pfd.cAlphaBits:
+            log.info("WGL pixel format has %i alpha bits despite requesting 0"
+                     " — DWM may composite with per-pixel alpha", pfd.cAlphaBits)
         context = wglCreateContext(self.hdc)
         assert context, "wglCreateContext failed"
         log("wglCreateContext(%#x)=%#x", self.hdc, context)
@@ -256,3 +259,45 @@ class WGLContext:
 
 
 GLContext = WGLContext
+
+
+def setup_intel_workarounds(backing_class) -> None:
+    """Override _fixup_present_alpha for Intel GPU DWM alpha workaround.
+
+    Intel's ChoosePixelFormat returns alpha bits even when none are requested.
+    DWM reads undefined alpha as transparent, causing window bleed-through
+    (freedesktop.org bug #14165). We force alpha=1 via glColorMask+glClear,
+    but Intel's glClear doesn't properly respect glColorMask without a prior
+    readback from the draw framebuffer to prime the driver.
+    """
+    from OpenGL.GL import (
+        GL_RGBA, GL_UNSIGNED_BYTE, GL_TEXTURE_RECTANGLE,
+        glGetIntegerv, glClearColor, glClear, glColorMask, glReadPixels, glReadBuffer,
+        GL_COLOR_BUFFER_BIT, GL_FALSE, GL_TRUE,
+    )
+    from OpenGL.GL.ARB.framebuffer_object import (
+        GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_DRAW_FRAMEBUFFER_BINDING,
+        glBindFramebuffer, glFramebufferTexture2D,
+    )
+    from xpra.opengl.backing import TEX_FBO
+    log.info("Intel GPU detected — enabling DWM alpha workarounds")
+
+    def _fixup_present_alpha(self) -> None:
+        if self._alpha_enabled:
+            return
+        if not getattr(self, '_intel_primed', False):
+            self._intel_primed = True
+            draw_fb = glGetIntegerv(GL_DRAW_FRAMEBUFFER_BINDING)
+            glBindFramebuffer(GL_READ_FRAMEBUFFER, draw_fb)
+            glReadPixels(0, 0, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE)
+            glBindFramebuffer(GL_READ_FRAMEBUFFER, self.offscreen_fbo)
+            glFramebufferTexture2D(GL_READ_FRAMEBUFFER, GL_COLOR_ATTACHMENT0,
+                                   GL_TEXTURE_RECTANGLE, self.textures[TEX_FBO], 0)
+            glReadBuffer(GL_COLOR_ATTACHMENT0)
+            glReadPixels(0, 0, 1, 1, GL_RGBA, GL_UNSIGNED_BYTE)
+        glColorMask(GL_FALSE, GL_FALSE, GL_FALSE, GL_TRUE)
+        glClearColor(0, 0, 0, 1)
+        glClear(GL_COLOR_BUFFER_BIT)
+        glColorMask(GL_TRUE, GL_TRUE, GL_TRUE, GL_TRUE)
+
+    backing_class._fixup_present_alpha = _fixup_present_alpha


### PR DESCRIPTION
### Problem

On Win32 with Intel integrated GPUs, OpenGL windows show content from windows behind them bleeding through character/text backgrounds. Affects both native WGL and GtkGLArea rendering paths.

**Root cause**: Intel's `ChoosePixelFormat` returns a pixel format with 8 alpha bits even when `cAlphaBits=0` is requested. DWM reads undefined alpha from the window surface as transparent ([freedesktop.org bug #14165](https://bugs.freedesktop.org/show_bug.cgi?id=14165)).

Confirmed on Intel(R) Graphics, driver build 32.0.101.8508. Does not affect NVIDIA, AMD, or Adreno (ARM64/GLon12).

### Fix

The workaround is Intel+Win32-specific, gated on `GL_VENDOR` containing "Intel". The bulk of the workaround logic lives in `platform/win32/gl_context.py` to keep platform-specific hacks out of the shared OpenGL code. The shared `backing.py` only adds a no-op `_fixup_present_alpha()` hook that the Win32 code overrides.

**Intel+Win32 workarounds:**
- Force RGBA visual on GL windows so the GDI surface has a proper alpha channel (`client_window.py`)
- Force alpha in GtkGLArea readback so the surface gets alpha=255 (`glarea_backing.py`)
- Force alpha=1 via `glColorMask`+`glClear` before each present, with a one-time `glReadPixels` to prime the Intel driver — Intel's `glClear` doesn't properly respect `glColorMask` without a prior readback (`gl_context.py:setup_intel_workarounds`)

**Platform-independent:**
- Clear non-alpha FBOs with alpha=1 instead of alpha=0 (`backing.py`)
- Add `_fixup_present_alpha` hook in `do_present_fbo` (`backing.py`)
- Set `app_paintable` on GL DrawingArea — matches the Cairo path (`drawing_area.py`)

### Testing

Tested on Win32 x64 with Intel(R) Graphics (driver 32.0.101.8508):
- `opengl=force` (native WGL path) — no bleedthrough
- `opengl=force:glarea` (GtkGLArea path) — no bleedthrough
- `opengl=off` (Cairo) — unaffected, still works

Tested on Win32 ARM64 with Adreno X1-85 (GLon12) — no regression, workaround not activated.

Confirmed `WS_EX_LAYERED` is NOT set on any decorated GL window after the RGBA visual change.

### References
- [freedesktop.org #14165](https://bugs.freedesktop.org/show_bug.cgi?id=14165) — i965 glClear + glColorMask
- [Mozilla #1523030](https://bugzilla.mozilla.org/show_bug.cgi?id=1523030) — glBlitFramebuffer ignores glColorMask
- [Xpra #2466](https://github.com/Xpra-org/xpra/issues/2466) — related GTK3 OpenGL Win32 transparency

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Sponsored-By: Netflix