### PR TITLE
Fix keyboard repeat rate lost after setxkbmap

### DIFF
--- a/xpra/server/subsystem/keyboard.py
+++ b/xpra/server/subsystem/keyboard.py
@@ -355,7 +355,7 @@ class KeyboardServer(StubServerMixin):
         """ Schedules/cancels the key repeat timeouts """
         self.cancel_key_repeat_timer()
         if pressed:
-            delay_ms = min(1500, max(250, delay_ms))
+            delay_ms = min(2000, max(1000, delay_ms))
             log("scheduling key repeat timer with delay %s for %s / %s", delay_ms, keyname, keycode)
             now = monotonic()
             self.key_repeat_timer = GLib.timeout_add(delay_ms, self._key_repeat_timeout,

--- a/xpra/x11/subsystem/keyboard.py
+++ b/xpra/x11/subsystem/keyboard.py
@@ -344,3 +344,6 @@ class X11KeyboardServer(KeyboardServer):
             # pylint: disable=access-member-before-definition
             server_source.set_keymap(self.keyboard_config, self.keys_pressed, force, translate_only)
             self.keyboard_config = server_source.keyboard_config
+        # setxkbmap resets X11 autorepeat to defaults, so re-apply:
+        if self.key_repeat_delay > 0 and self.key_repeat_interval > 0:
+            self.set_keyboard_repeat(self.key_repeat_delay, self.key_repeat_interval)


### PR DESCRIPTION
## Summary

- Re-apply the client's keyboard repeat rate after every `set_keymap` call, since `XkbGetKeyboardByName(load=True)` resets X11 autorepeat controls to the XKB keymap defaults
- Raise the stuck-key safety timeout floor from 250ms to 1000ms to prevent it from racing with X11 autorepeat

## Problem

When a client attaches (or re-attaches) to an xpra session, `parse_hello_ui_keyboard` correctly applies the client's repeat rate via `set_keyboard_repeat`, but then immediately calls `set_keymap` which invokes `XkbGetKeyboardByName(..., load=True)`. Loading a new XKB keyboard description resets all autorepeat controls to the keymap defaults (typically 660ms delay / 40ms interval), discarding the client's settings.

This affects every client attach, layout switch (`_process_layout`), and keymap update (`_process_keymap_changed`).

Additionally, the previous stuck-key timeout floor of 250ms could race with X11 autorepeat startup when the client's repeat delay was also ~250ms, causing a stutter pattern: a few fast repeats from X11 autorepeat, then a pause when the timeout fired and unpressed the key, then repeat when the client's key-repeat packet re-pressed it.

## Fix

1. **`xpra/x11/subsystem/keyboard.py`**: At the end of `set_keymap`, re-apply the stored `key_repeat_delay` and `key_repeat_interval` if they are valid. This covers all call sites (attach, layout change, keymap change).

2. **`xpra/server/subsystem/keyboard.py`**: Raise the timeout clamp from `min(1500, max(250, delay_ms))` to `min(2000, max(1000, delay_ms))`. At 1000ms the timeout comfortably outlasts the client's key-repeat packet cadence at any reasonable latency, while still releasing stuck keys within ~1 second.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Sponsored-By: Netflix