### PR TITLE
Fix nvenc h265 lossless support and prefer h265 over h264

### DIFF
--- a/xpra/codecs/constants.py
+++ b/xpra/codecs/constants.py
@@ -28,11 +28,11 @@ FAST_DECODE_MIN_SPEED: int = envint("XPRA_FAST_DECODE_MIN_SPEED", 70)
 # note: this is just for defining the order of encodings,
 # so we have both core encodings (rgb24/rgb32) and regular encodings (rgb) in here:
 PREFERRED_ENCODING_ORDER: Sequence[str] = (
-    "h264", "vp9", "vp8", "mpeg4",
+    "h265", "h264", "vp9", "vp8", "mpeg4",
     "mpeg4+mp4", "h264+mp4", "vp8+webm", "vp9+webm",
     "png", "png/P", "png/L", "webp", "avif",
     "rgb", "rgb24", "rgb32", "jpeg", "jpega",
-    "h265", "av1",
+    "av1",
     "scroll",
     "grayscale",
     "stream",

--- a/xpra/codecs/nvidia/nvenc/encoder.pyx
+++ b/xpra/codecs/nvidia/nvenc/encoder.pyx
@@ -247,7 +247,7 @@ def _get_spec(encoding: str, in_cs: str, out_css: Sequence[str]) -> VideoSpec:
     has_lossless_mode = LOSSLESS_CODEC_SUPPORT.get(encoding, LOSSLESS_ENABLED)
     width_mask = get_width_mask(in_cs)
     height_mask = get_height_mask(in_cs)
-    has_lossless_mode = in_cs in ("XRGB", "BGRX", "r210") and encoding == "h264"
+    has_lossless_mode = in_cs in ("XRGB", "BGRX", "r210") and LOSSLESS_CODEC_SUPPORT.get(encoding, LOSSLESS_ENABLED)
 
     #the output will actually be in one of those two formats once decoded
     #because internally that's what we convert to before encoding


### PR DESCRIPTION
## Summary
- Fix `has_lossless_mode` in nvenc encoder spec to use probed `LOSSLESS_CODEC_SUPPORT` instead of hardcoding h264-only. This was causing h265 to get `quality=60` vs h264's `quality=100`, leading to unstable encoder flip-flopping as dynamic target quality fluctuated.
- Move h265 ahead of h264 in `PREFERRED_ENCODING_ORDER`. h265 was left at the bottom (after png, jpeg, rgb) as a legacy artifact from when it was in `PROBLEMATIC_ENCODINGS` (removed 2020, commit b0b1d12024).

## Details
The nvenc `_get_spec()` function (encoder.pyx:250) hardcoded `has_lossless_mode = encoding == "h264"`, overwriting the correctly probed value from line 247. This meant h265 got `quality=60+0=60` while h264 got `quality=60+40=100` in the VideoSpec, even though nvenc hardware supports lossless h265 (verified via `NV_ENC_CAPS_SUPPORT_LOSSLESS_ENCODE` probe at init time).

The quality spec difference caused the scoring to flip-flop: at target_quality ~67, h265's quality=60 was closer to target (+26 quality score points), but h264 had +17 from its higher position in `PREFERRED_ENCODING_ORDER`. As target quality fluctuated, the winner alternated, defeating the edge resistance mechanism.

### Why h265 ahead of h264
- Better compression at same quality on hardware encode paths
- No practical latency or power difference with hardware encode/decode
- No software h265 encoder exists in xpra — no footgun risk
- Clients without h265 hw decode don't advertise it, auto-fallback to h264
- av1 intentionally left low — has slow sw encoder (av1enc via gstreamer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Sponsored-By: Netflix