### PR TITLE
Fix session info graphs not populating

### DIFF
--- a/xpra/client/gtk3/client_base.py
+++ b/xpra/client/gtk3/client_base.py
@@ -670,7 +670,7 @@ class GTKXpraClient(GObjectClientAdapter, UIXpraClient):
             force_focus()
             dialog.present()
             return
-        conn = getattr(self._protocol, "._conn", None)
+        conn = getattr(self._protocol, "_conn", None)
         from xpra.gtk.dialogs.session_info import SessionInfo
         dialog = SessionInfo(self, self.session_name, conn)
         dialog.set_args(*args)


### PR DESCRIPTION
## Summary

- Fix typo in `getattr(self._protocol, "._conn", None)` → `"_conn"` (no dot)
- The erroneous dot meant the attribute was never found, so `conn` was always `None`
- `populate()` bailed out immediately at `if not conn: return False`, so no bandwidth or latency data was ever collected for the Graphs tab
- Introduced in commit 5e056cd32c ("simplify", May 2024)

Sponsored-By: Netflix