### PR TITLE
prefer av1 over h264 in encoding order

### DIFF
--- a/xpra/codecs/constants.py
+++ b/xpra/codecs/constants.py
@@ -28,11 +28,10 @@ FAST_DECODE_MIN_SPEED: int = envint("XPRA_FAST_DECODE_MIN_SPEED", 70)
 # note: this is just for defining the order of encodings,
 # so we have both core encodings (rgb24/rgb32) and regular encodings (rgb) in here:
 PREFERRED_ENCODING_ORDER: Sequence[str] = (
-    "h265", "h264", "vp9", "vp8", "mpeg4",
+    "h265", "av1", "h264", "vp9", "vp8", "mpeg4",
     "mpeg4+mp4", "h264+mp4", "vp8+webm", "vp9+webm",
     "png", "png/P", "png/L", "webp", "avif",
     "rgb", "rgb24", "rgb32", "jpeg", "jpega",
-    "av1",
     "scroll",
     "grayscale",
     "stream",
@@ -46,9 +45,8 @@ PREFERRED_REFRESH_ENCODING_ORDER: Sequence[str] = (
     "webp", "avif", "png", "png/P", "png/L", "rgb", "rgb24", "rbg32", "jpeg", "jpega",
 )
 STREAM_ENCODINGS: Sequence[str] = (
-    "h264", "vp9", "vp8", "mpeg4",
+    "h265", "av1", "h264", "vp9", "vp8", "mpeg4",
     "mpeg4+mp4", "h264+mp4", "vp8+webm", "vp9+webm",
-    "h265", "av1",
 )
 
 # encoding order for edges (usually one pixel high or wide):
@@ -62,7 +60,7 @@ HELP_ORDER: Sequence[str] = (
     "auto",
     "stream",
     "grayscale",
-    "h264", "h265", "av1", "vp8", "vp9", "mpeg4",
+    "h265", "av1", "h264", "vp8", "vp9", "mpeg4",
     "png", "png/P", "png/L", "webp", "avif",
     "rgb", "jpeg", "jpega",
     "scroll",


### PR DESCRIPTION
## Summary

- Move av1 from below all image encodings to right after h265 in `PREFERRED_ENCODING_ORDER`, `STREAM_ENCODINGS`, and `HELP_ORDER`

av1 was ranked below jpeg/rgb/png due to a concern about the slow gstreamer `av1enc` software encoder being selected on systems without hardware av1 encode. This concern was misplaced: gstreamer video encoders are already deprioritized at the encoder selection layer (`PREFERRED_ENCODER_ORDER` in `video.py` puts gstreamer last), so the encoding preference order doesn't need to work around that.

With dedicated hardware encoders (nvenc, amf) and a native aom decoder (#4618), av1 is a first-class codec that offers better compression efficiency than h264 and should be preferred when available.

### Why av1 is placed after h265 (for now)

The AV1 codec standard achieves ~30% bitrate savings over HEVC at equivalent visual quality with reference encoders ([Bitmovin multi-codec study](https://bitmovin.com/blog/av1-multi-codec-dash-dataset/), [Moscow State University testing](https://www.compression.ru/), [Cambridge University Press analysis](https://www.cambridge.org/core/journals/apsipa-transactions-on-signal-and-information-processing/article/compression-efficiency-analysis-of-av1-vvc-and-hevc-for-random-access-applications/D2345DDC3750055AB0AA3D24FCF743BE)). However, hardware encoder implementations don't reach this ceiling — NVIDIA's own NVENC benchmarks compare AV1 against H.264 (showing [40% bitrate savings at 1080p60](https://developer.nvidia.com/blog/improving-video-quality-and-performance-with-av1-and-nvidia-ada-lovelace-architecture/)) but notably avoid publishing direct NVENC AV1 vs NVENC HEVC quality comparisons, suggesting the gap between their AV1 and HEVC hardware encoders is modest.

Additionally, NVENC HEVC has had many more hardware generations to mature (available since Maxwell 2014 vs AV1 since Ada Lovelace 2022), and HEVC hardware encode is available on a much wider range of GPUs. As hardware AV1 encoder quality improves in future GPU generations, it may make sense to promote av1 above h265.

See discussion in #4850 (comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Sponsored-By: Netflix