### PR TITLE
Fix About dialog empty on second open

### DIFF
--- a/xpra/gtk/dialogs/about.py
+++ b/xpra/gtk/dialogs/about.py
@@ -46,8 +46,10 @@ about_dialog: Gtk.AboutDialog | None = None
 
 
 def close_about(*_args) -> None:
+    global about_dialog
     if about_dialog:
-        about_dialog.hide()
+        about_dialog.destroy()
+        about_dialog = None
 
 
 def about(on_close=close_about, parent: Gtk.Window | None = None):


### PR DESCRIPTION
## Summary
- `close_about()` only called `hide()`, but closing via the window manager's X button fires `delete-event` which destroys the widget
- The stale global reference then showed an empty window on re-open
- Now `destroy()` and clear the reference so a fresh dialog is created each time

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Sponsored-By: Netflix