### PR TITLE
Fix session info graph labels for HiDPI displays

### DIFF
--- a/xpra/common.py
+++ b/xpra/common.py
@@ -33,6 +33,9 @@ def gravity_str(v) -> str:
         return str(v)
 
 
+DEFAULT_DPI: int = 96
+
+
 def noop(*_args, **_kwargs) -> None:
     """ do nothing """
 

--- a/xpra/gtk/dialogs/session_info.py
+++ b/xpra/gtk/dialogs/session_info.py
@@ -1265,6 +1265,10 @@ class SessionInfo(Gtk.Window):
         if h <= 0:
             return True
         start_x_offset = min(1.0, (monotonic() - self.last_populate_time) * 0.95)
+        from xpra.common import DEFAULT_DPI
+        screen = Gdk.Screen.get_default()
+        dpi = screen.get_resolution() if screen else -1
+        scale = max(1, dpi / DEFAULT_DPI) if dpi > 0 else self.get_scale_factor()
         rect = box.get_allocation()
         maxw, maxh = self.client.get_root_size()
         ngraphs = 2 + int(SHOW_SOUND_STATS)
@@ -1317,7 +1321,8 @@ class SessionInfo(Gtk.Window):
             surface = make_graph_imagesurface(datasets, labels=labels,
                                               width=w, height=h,
                                               title="Bandwidth", min_y_scale=10, rounding=10,
-                                              start_x_offset=start_x_offset)
+                                              start_x_offset=start_x_offset,
+                                              scale=scale)
             set_graph_surface(self.bandwidth_graph, surface)
 
         def norm_lists(items, size=N_SAMPLES) -> tuple:
@@ -1353,7 +1358,8 @@ class SessionInfo(Gtk.Window):
         surface = make_graph_imagesurface(latency_values, labels=latency_labels,
                                           width=w, height=h,
                                           title="Latency (ms)", min_y_scale=10, rounding=25,
-                                          start_x_offset=start_x_offset)
+                                          start_x_offset=start_x_offset,
+                                          scale=scale)
         set_graph_surface(self.latency_graph, surface)
 
         if features.audio and SHOW_SOUND_STATS and self.client.audio_sink:
@@ -1369,7 +1375,8 @@ class SessionInfo(Gtk.Window):
             surface = make_graph_imagesurface(queue_values, labels=queue_labels,
                                               width=w, height=h,
                                               title="Audio Buffer (ms)", min_y_scale=10, rounding=25,
-                                              start_x_offset=start_x_offset)
+                                              start_x_offset=start_x_offset,
+                                              scale=scale)
             set_graph_surface(self.audio_queue_graph, surface)
         return True
 

--- a/xpra/gtk/graph.py
+++ b/xpra/gtk/graph.py
@@ -5,6 +5,11 @@
 
 import math
 import cairo
+from xpra.os_util import gi_import
+from xpra.common import DEFAULT_DPI
+
+PangoCairo = gi_import("PangoCairo")
+Pango = gi_import("Pango")
 
 DEFAULT_COLOURS = ((0.8, 0, 0), (0, 0, 0.8), (0.1, 0.65, 0.1), (0, 0.6, 0.6), (0.1, 0.1, 0.1))
 
@@ -19,28 +24,39 @@ def round_up_unit(i: int, rounding=10) -> int:
     return v * rounding
 
 
+def _text_size(layout, text: str) -> tuple[int, int]:
+    layout.set_text(text, -1)
+    _, logical = layout.get_pixel_extents()
+    return logical.width, logical.height
+
+
+def _y_label(scale_y: int | float, i: int) -> str:
+    if scale_y < 10:
+        return str(int(scale_y * i) / 10.0)
+    return str(int(scale_y * i / 10))
+
+
 def make_graph_imagesurface(data, labels=None, width=320, height=200, title=None,
                             show_y_scale=True, show_x_scale=False,
                             min_y_scale=None, rounding=10,
                             start_x_offset=0.0,
-                            colours=DEFAULT_COLOURS, dots=False, curves=True) -> cairo.ImageSurface:
+                            colours=DEFAULT_COLOURS, dots=False, curves=True,
+                            scale=1) -> cairo.ImageSurface:
     # print("make_graph_pixmap(%s, %s, %s, %s, %s, %s, %s, %s, %s)" % (data, labels, width, height, title,
     #                  show_y_scale, show_x_scale, min_y_scale, colours))
     surface = cairo.ImageSurface(cairo.Format.RGB24, width, height)  # pylint: disable=no-member
-    y_label_chars = 4
-    x_offset = y_label_chars * 8
-    y_offset = 20
-    over = 2
-    radius = 2
-    # inner dimensions (used for graph only)
-    w = width - x_offset
-    h = height - y_offset * 2
     context = cairo.Context(surface)  # pylint: disable=no-member
-    # fill with white:
-    context.rectangle(0, 0, width, height)
-    context.set_source_rgb(1, 1, 1)
-    context.fill()
-    # find ranges:
+
+    # set up Pango for DPI-aware text rendering
+    layout = PangoCairo.create_layout(context)
+    pctx = layout.get_context()
+    PangoCairo.context_set_resolution(pctx, DEFAULT_DPI * scale)
+
+    axis_font = Pango.FontDescription("Sans 9")
+    title_font = Pango.FontDescription("Serif 10")
+    legend_font = Pango.FontDescription("Serif 9")
+
+    # find data ranges first so we can measure actual labels
     max_y = 0
     max_x = 0
     for line_data in data:
@@ -50,11 +66,40 @@ def make_graph_imagesurface(data, labels=None, width=320, height=200, title=None
                 max_y = max(max_y, y)
             x += 1
             max_x = max(max_x, x)
-    # round up the scales:
     scale_x = max_x
     if min_y_scale is not None:
         max_y = max(max_y, min_y_scale)
     scale_y = round_up_unit(max_y, rounding)
+
+    # compute margins from actual text metrics
+    layout.set_font_description(axis_font)
+    # measure the widest Y label for left margin
+    max_label_w = 0
+    for i in range(0, 11):
+        lw, _ = _text_size(layout, _y_label(scale_y, i))
+        max_label_w = max(max_label_w, lw)
+    _, label_h = _text_size(layout, "0")
+    x_offset = max_label_w + 6
+
+    layout.set_font_description(title_font)
+    _, title_h = _text_size(layout, "Ag")
+    y_offset = title_h + 4
+
+    over = 2
+    radius = 2
+    # inner dimensions (used for graph only)
+    w = width - x_offset
+    h = height - y_offset * 2
+
+    # skip Y labels that would overlap
+    grid_spacing = h / 10
+    layout.set_font_description(axis_font)
+    y_label_step = max(1, math.ceil(label_h * 1.3 / grid_spacing))
+
+    # fill with white:
+    context.rectangle(0, 0, width, height)
+    context.set_source_rgb(1, 1, 1)
+    context.fill()
     # use black:
     context.set_source_rgb(0, 0, 0)
     # border:
@@ -70,27 +115,19 @@ def make_graph_imagesurface(data, labels=None, width=320, height=200, title=None
     # show horizontal line:
     context.move_to(x_offset - over, height - y_offset)
     context.line_to(width, height - y_offset)
-    # units:
-    context.select_font_face('Sans')
-    context.set_font_size(10)
     # scales
+    layout.set_font_description(axis_font)
     for i in range(0, 11):
         if show_y_scale:
-            context.set_source_rgb(0, 0, 0)
-            context.set_line_width(1)
             # vertical:
             y = height - y_offset - h * i / 10
-            # text
-            if scale_y < 10:
-                unit = str(int(scale_y * i) / 10.0)
-            else:
-                unit = str(int(scale_y * i / 10))
-            context.move_to(x_offset - 3 - (x_offset - 6) / y_label_chars * min(y_label_chars, len(unit)), y + 3)
-            context.show_text(unit)
-            # line indicator
+            # tick mark
+            context.set_source_rgb(0, 0, 0)
+            context.set_line_width(1)
             context.move_to(x_offset - over, y)
             context.line_to(x_offset + over, y)
             context.stroke()
+            # grid line
             context.move_to(x_offset + over, y)
             context.set_source_rgb(0.5, 0.5, 0.5)
             context.set_line_width(0.5)
@@ -98,15 +135,23 @@ def make_graph_imagesurface(data, labels=None, width=320, height=200, title=None
             context.line_to(width, y)
             context.stroke()
             context.set_dash([])
+            # label (skip if it would overlap)
+            if i % y_label_step == 0:
+                unit = _y_label(scale_y, i)
+                uw, uh = _text_size(layout, unit)
+                context.set_source_rgb(0, 0, 0)
+                context.move_to(x_offset - uw - 2, y - uh / 2)
+                PangoCairo.show_layout(context, layout)
         if show_x_scale:
             context.set_source_rgb(0, 0, 0)
             context.set_line_width(1)
             # horizontal:
             x = x_offset + w * i / 10
             # text
-            context.move_to(x - 2, height - 2)
             unit = str(int(scale_x * i / 10))
-            context.show_text(unit)
+            uw, uh = _text_size(layout, unit)
+            context.move_to(x - uw / 2, height - uh - 1)
+            PangoCairo.show_layout(context, layout)
             # line indicator
             context.move_to(x, height - y_offset - over)
             context.line_to(x, height - y_offset + over)
@@ -114,10 +159,10 @@ def make_graph_imagesurface(data, labels=None, width=320, height=200, title=None
     # title:
     if title:
         context.set_source_rgb(0.2, 0.2, 0.2)
-        context.select_font_face('Serif')
-        context.set_font_size(14)
-        context.move_to(x_offset + w / 2 - len(title) * 14 / 2, 14)
-        context.show_text(title)
+        layout.set_font_description(title_font)
+        tw, th = _text_size(layout, title)
+        context.move_to(x_offset + (w - tw) / 2, 1)
+        PangoCairo.show_layout(context, layout)
         context.stroke()
     # now draw the actual data, clipped to the graph region:
     context.save()
@@ -161,15 +206,15 @@ def make_graph_imagesurface(data, labels=None, width=320, height=200, title=None
             j += 1
         context.stroke()
     context.restore()
+    # legend:
+    layout.set_font_description(legend_font)
     for i, line_data in enumerate(data):
-        # show label:
         if labels and len(labels) > i:
             label = labels[i]
             colour = colours[i % len(colours)]
             context.set_source_rgb(*colour)
-            context.select_font_face('Serif')
-            context.set_font_size(12)
-            context.move_to(x_offset / 2 + (width - x_offset) * i / len(labels), height - 4)
-            context.show_text(label)
+            lw, lh = _text_size(layout, label)
+            context.move_to(x_offset / 2 + (width - x_offset) * i / len(labels), height - lh - 1)
+            PangoCairo.show_layout(context, layout)
             context.stroke()
     return surface


### PR DESCRIPTION
## Summary
- Replace Cairo toy text API with PangoCairo for DPI-aware graph text rendering
- Pango uses point-based font sizes scaled by the display's DPI resolution, so graph labels (title, Y axis, legend) render at the correct size on HiDPI displays
- Compute DPI scale from `Gdk.Screen.get_resolution()`, falling back to `get_scale_factor()`
- Measure actual Y label widths for left margin instead of fixed character-width estimate
- Skip Y axis labels that would overlap based on text height vs grid spacing
- Add `DEFAULT_DPI` constant (96) to `xpra.common`

Note: X11 GLX and macOS may need similar DPI detection changes but are not included since we cannot test them.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>
Sponsored-By: Netflix