### PR TITLE
QUIC substreams: independent streams for audio, video, and input

### DIFF
--- a/tests/scripts/test_quic_hol.py
+++ b/tests/scripts/test_quic_hol.py
@@ -1,0 +1,720 @@
+#!/usr/bin/env python3
+# This file is part of Xpra.
+# Copyright (C) 2026 Netflix, Inc.
+# Xpra is released under the terms of the GNU GPL v2, or, at your option, any
+# later version. See the file COPYING for details.
+# ABOUTME: Measures QUIC head-of-line blocking by connecting to an xpra server
+# ABOUTME: and timestamping packet arrivals with and without substreams enabled.
+
+"""
+QUIC Head-of-Line Blocking Test
+
+Connects to a live xpra server via QUIC and measures inter-arrival jitter
+of transport-level data chunks. Runs two passes:
+  1. Single-stream (no quic.substreams capability)
+  2. Multi-stream (with quic.substreams capability)
+
+Generate traffic on the xpra display first (e.g., glxgears), then run:
+
+    python3 test_quic_hol.py quic://HOST:PORT/ --password PASS
+
+Options:
+    --duration N      seconds per test pass (default: 10)
+    --single-only     only run single-stream test
+    --multi-only      only run multi-stream test
+"""
+
+import os
+import sys
+import time
+import argparse
+import statistics
+from collections import defaultdict
+
+# Add xpra source tree to path
+script_dir = os.path.dirname(os.path.abspath(__file__))
+src_root = os.path.abspath(os.path.join(script_dir, "..", ".."))
+if os.path.isdir(os.path.join(src_root, "xpra")):
+    sys.path.insert(0, src_root)
+
+
+class PacketTimingCollector:
+    """Collects timestamps for each packet category."""
+
+    def __init__(self):
+        self.arrivals: dict[str, list[float]] = defaultdict(list)
+        self.sizes: dict[str, list[int]] = defaultdict(list)
+        self.network_jitter: list[float] = []
+        self.start_time = 0.0
+        self.collecting = False
+
+    def start(self):
+        self.arrivals.clear()
+        self.sizes.clear()
+        self.network_jitter.clear()
+        self.start_time = time.monotonic()
+        self.collecting = True
+
+    def stop(self):
+        self.collecting = False
+
+    def record(self, category: str, size: int):
+        if self.collecting:
+            self.arrivals[category].append(time.monotonic())
+            self.sizes[category].append(size)
+
+    def inter_arrival_ms(self, category: str) -> list[float]:
+        times = self.arrivals.get(category, [])
+        if len(times) < 2:
+            return []
+        return [(times[i] - times[i - 1]) * 1000 for i in range(1, len(times))]
+
+    def report(self, label: str):
+        elapsed = time.monotonic() - self.start_time if self.start_time else 0
+        print(f"\n{'=' * 60}")
+        print(f"  {label}")
+        print(f"  Duration: {elapsed:.1f}s")
+        print(f"{'=' * 60}")
+
+        for cat in sorted(self.arrivals.keys()):
+            count = len(self.arrivals[cat])
+            total_bytes = sum(self.sizes[cat])
+            ia = self.inter_arrival_ms(cat)
+            if not ia:
+                print(f"\n  {cat}: {count} chunks ({total_bytes:,} bytes)")
+                continue
+            sorted_ia = sorted(ia)
+            rate = count / elapsed if elapsed > 0 else 0
+            print(f"\n  {cat}: {count} chunks ({total_bytes:,} bytes, {rate:.1f}/s)")
+            print(f"    inter-arrival (ms): "
+                  f"mean={statistics.mean(ia):.1f}  "
+                  f"p50={sorted_ia[int(len(ia) * 0.50)]:.1f}  "
+                  f"p95={sorted_ia[int(len(ia) * 0.95)]:.1f}  "
+                  f"p99={sorted_ia[min(int(len(ia) * 0.99), len(ia) - 1)]:.1f}  "
+                  f"max={max(ia):.1f}")
+            if len(ia) > 1:
+                print(f"    jitter (stdev): {statistics.stdev(ia):.1f} ms")
+
+        if self.network_jitter and len(self.network_jitter) > 1:
+            nj = sorted(self.network_jitter)
+            print(f"\n  sound network jitter (arrival_diff - send_diff):")
+            print(f"    samples={len(nj)}  "
+                  f"mean={statistics.mean(nj):.1f}ms  "
+                  f"p50={nj[int(len(nj) * 0.50)]:.1f}ms  "
+                  f"p95={nj[int(len(nj) * 0.95)]:.1f}ms  "
+                  f"max={max(nj):.1f}ms  "
+                  f"stdev={statistics.stdev(nj):.1f}ms")
+
+
+def _ensure_substream_support():
+    """Patch WebSocketClient with substream receive support if missing.
+
+    The server overrides add substream send/receive to connection.py, listener.py,
+    etc., but xpra.net.quic.client is client-only and may not be overridden.
+    Without this patch, the server routes draws to raw QUIC streams that the
+    client silently drops — resulting in zero draw traffic to measure.
+    """
+    from xpra.net.quic.client import WebSocketClient, ClientWebSocketConnection
+    if hasattr(WebSocketClient, '_handle_substream_data'):
+        return  # already patched or running from source with full support
+
+    # ClientWebSocketConnection may have inherited from the system
+    # XpraQuicConnection (without substream methods) due to import ordering.
+    # Patch the missing methods directly onto the class.
+    if not hasattr(ClientWebSocketConnection, '_raw_read_cb'):
+        ClientWebSocketConnection._raw_read_cb = None
+
+    if not hasattr(ClientWebSocketConnection, 'put_raw_substream_data'):
+        def put_raw_substream_data(self, data, stream_id=1):
+            if self._raw_read_cb:
+                self._raw_read_cb(data, stream_id)
+        ClientWebSocketConnection.put_raw_substream_data = put_raw_substream_data
+
+    from aioquic.quic.events import StreamDataReceived
+
+    def _is_server_bidirectional(self, stream_id):
+        from aioquic.quic.connection import stream_is_client_initiated, stream_is_unidirectional
+        return not stream_is_client_initiated(stream_id) and not stream_is_unidirectional(stream_id)
+
+    def _deliver_substream(self, websocket, data, stream_id):
+        """Deliver substream data to the connection's read path."""
+        websocket.put_raw_substream_data(data, stream_id)
+
+    def _handle_substream_data(self, event):
+        stream_id = event.stream_id
+        websocket = self._substream_map.get(stream_id)
+        if websocket:
+            self._deliver_substream(websocket, event.data, stream_id)
+            return True
+        if not self._is_server_bidirectional(stream_id):
+            return False
+        buf = self._substream_buffers.get(stream_id, b"") + event.data
+        if b"\n" not in buf:
+            self._substream_buffers[stream_id] = buf
+            return True
+        header, remainder = buf.split(b"\n", 1)
+        self._substream_buffers.pop(stream_id, None)
+        header_str = header.decode()
+        if not header_str.startswith("xpra:"):
+            return False
+        stream_type = header_str[5:]
+        websocket = next(iter(self._websockets.values()), None)
+        if not websocket:
+            return True
+        self._substream_map[stream_id] = websocket
+        print(f"  substream {stream_id} registered for {stream_type!r}")
+        if remainder:
+            self._deliver_substream(websocket, remainder, stream_id)
+        return True
+
+    _orig_quic_event = WebSocketClient.quic_event_received
+
+    def quic_event_received(self, event):
+        if isinstance(event, StreamDataReceived) and self._handle_substream_data(event):
+            return
+        _orig_quic_event(self, event)
+
+    _orig_init = WebSocketClient.__init__
+
+    def patched_init(self, *args, **kwargs):
+        _orig_init(self, *args, **kwargs)
+        if not hasattr(self, '_substream_map'):
+            self._substream_map = {}
+        if not hasattr(self, '_substream_buffers'):
+            self._substream_buffers = {}
+
+    WebSocketClient.__init__ = patched_init
+    WebSocketClient._is_server_bidirectional = _is_server_bidirectional
+    WebSocketClient._deliver_substream = _deliver_substream
+    WebSocketClient._handle_substream_data = _handle_substream_data
+    WebSocketClient.quic_event_received = quic_event_received
+    print("  (patched WebSocketClient with substream receive support)")
+
+
+def run_test(url: str, password: str, duration: float, substreams: bool, sync_interval: int = 0) -> tuple:
+    """Connect to the server, collect transport-level timing.
+
+    Returns (parse_collector, quic_collector) — the parse collector timestamps
+    packets after the parse thread processes them, the quic collector timestamps
+    raw substream data as it arrives from the QUIC layer (before parse thread).
+    """
+    from xpra.net.packet_encoding import init_all as init_encoders
+    from xpra.net.compression import init_all as init_compressors
+    init_encoders()
+    init_compressors()
+    if substreams:
+        _ensure_substream_support()
+
+    from gi.repository import GLib
+    from xpra.client.base import features
+    features.file = features.printer = features.control = features.debug = False
+
+    from xpra.client.base.command import MonitorXpraClient
+    from xpra.util.objects import typedict
+    from xpra.scripts.config import make_defaults_struct
+    from xpra.scripts.main import connect_to_server, do_pick_display
+
+    collector = PacketTimingCollector()
+    quic_collector = PacketTimingCollector()
+
+    opts = make_defaults_struct()
+    opts.ssl_server_verify_mode = "none"
+    if password:
+        opts.password = password
+
+    class TimingClient(MonitorXpraClient):
+        def __init__(self, opts):
+            super().__init__(opts)
+            # override MonitorXpraClient defaults — request full UI data
+            self.hello_extra["ui_client"] = True
+            self.hello_extra["windows"] = True
+            self.hello_extra["keyboard"] = False
+            self.hello_extra["pointer"] = False
+            self.hello_extra["audio"] = {
+                "receive": True,
+                "decoders": ("opus+ogg", "vorbis+ogg", "flac", "wav"),
+                "send": False,
+            }
+            self.hello_extra["wants"] = self.hello_extra.get("wants", []) + ["audio"]
+            all_encodings = ("av1", "avif", "h264", "h265", "jpeg", "jpega",
+                             "png", "png/L", "png/P", "rgb24", "rgb32",
+                             "vp8", "vp9", "webp")
+            self.hello_extra["encodings"] = all_encodings
+            self.hello_extra["encoding.core"] = all_encodings
+            self.hello_extra["desktop_size"] = (1920, 1080)
+            self.hello_extra["screen_sizes"] = [(1920, 1080, 508, 286)]
+            # remove "request"="event" so server treats us as a UI client
+            self.hello_extra.pop("request", None)
+            # allow coexisting with other clients for simultaneous A/B testing
+            import uuid as _uuid
+            self.hello_extra["share"] = True
+            self.hello_extra["uuid"] = _uuid.uuid4().hex
+            # control substream capability — must explicitly set False to
+            # override get_network_caps() which adds True unconditionally
+            self.hello_extra["quic.substreams"] = substreams
+            print(f"  hello_extra quic.substreams = {self.hello_extra.get('quic.substreams', '<not set>')}")
+
+        @staticmethod
+        def handle_invalid_packet(proto, packet):
+            # silently accept all packet types
+            pass
+
+        def do_command(self, caps):
+            mode_str = "multi-stream" if substreams else "single-stream"
+            qs = caps.boolget("quic.substreams")
+            print(f"  Connected ({mode_str}), server quic.substreams={qs}")
+            # hook QUIC substream arrival timing (before parse thread)
+            self._hook_quic_timing()
+            # start the substream drain parser immediately so draws get acked
+            # during the pre-timing phase (prevents server throttling)
+            if substreams:
+                self._start_substream_drain()
+            # request the server to start sending audio
+            audio_caps = typedict(caps.dictget("audio") or {})
+            if audio_caps.boolget("send"):
+                codec = "opus+ogg"
+                print(f"  Requesting audio: {codec}")
+                self.send("sound-control", "start", codec)
+            else:
+                print(f"  Server audio send not available")
+            # wait for clock sync if requested
+            if sync_interval > 0:
+                import math
+                now = time.time()
+                next_boundary = math.ceil(now / sync_interval) * sync_interval
+                wait = next_boundary - now
+                print(f"  Waiting {wait:.1f}s for next {sync_interval}s boundary...")
+                GLib.timeout_add(int(wait * 1000), self._start_collecting)
+                return
+            self._start_collecting()
+
+        def _start_substream_drain(self):
+            """Wire substream data to a separate buffer and start drain timer.
+
+            Substream data goes to our own queue (not the protocol's _read_queue)
+            to avoid interleaving with main-stream WS data in the single-state
+            parser. The drain timer parses xpra packets and acks draws.
+            """
+            if hasattr(self, '_drain_timer') and self._drain_timer:
+                return  # already running
+            self._substream_queue = defaultdict(lambda: b"")
+            self._sq_lock = __import__('threading').Lock()
+            proto = getattr(self, "_protocol", None)
+            if proto:
+                conn = proto._conn
+                if not getattr(conn, '_raw_read_cb', None):
+                    sq = self._substream_queue
+                    sq_lock = self._sq_lock
+
+                    def substream_recv(data, stream_id):
+                        with sq_lock:
+                            sq[stream_id] += data
+
+                    conn._raw_read_cb = substream_recv
+            self._drain_timer = GLib.timeout_add(20, self._drain_substreams)
+
+        def _start_collecting(self):
+            print(f"  Collecting at {time.strftime('%H:%M:%S')} for {duration}s...")
+            # ensure drain is running (may already be from do_command)
+            if substreams:
+                self._start_substream_drain()
+            self._timing_mode = True
+            collector.start()
+            quic_collector.start()
+            GLib.timeout_add(int(duration * 1000), self._stop_collecting)
+            return False
+
+        def _drain_substreams(self):
+            """Parse xpra packets from substream buffers, record and ack draws."""
+            import struct
+            sq = getattr(self, '_substream_queue', {})
+            sq_lock = getattr(self, '_sq_lock', None)
+            for stream_id in list(sq.keys()):
+                # atomically swap the buffer so the asyncio thread can keep
+                # appending without racing with our parse/write-back
+                if sq_lock:
+                    with sq_lock:
+                        buf = sq[stream_id]
+                        sq[stream_id] = b""
+                else:
+                    buf = sq[stream_id]
+                    sq[stream_id] = b""
+                while len(buf) >= 8:
+                    # xpra header: 1 byte flag, 1 byte proto_flags, 1 byte comp,
+                    # 1 byte pkt_index, 4 byte data_size
+                    _, proto_flags, comp_level, pkt_index, data_size = struct.unpack(b'!cBBBL', buf[:8])
+                    total = 8 + data_size
+                    if len(buf) < total:
+                        break
+                    # only care about the main packet (pkt_index 0)
+                    if pkt_index == 0:
+                        payload = buf[8:total]
+                        if comp_level > 0:
+                            from xpra.net.compression import decompress
+                            payload = decompress(payload, comp_level)
+                        # try to decode just the packet type (first element)
+                        try:
+                            from xpra.net.packet_encoding import decode
+                            packet_data = decode(payload, proto_flags)
+                            if packet_data and len(packet_data) > 0:
+                                ptype = str(packet_data[0])
+                                size = len(payload)
+                                collector.record(ptype, size)
+                                if ptype == "draw" and len(packet_data) > 8:
+                                    wid = packet_data[1]
+                                    width = packet_data[4]
+                                    height = packet_data[5]
+                                    pkt_seq = packet_data[8]
+                                    self.send("damage-sequence", pkt_seq, wid,
+                                              width, height, 1, "")
+                                elif ptype == "sound-data" and len(packet_data) > 3:
+                                    now_ms = time.monotonic() * 1000
+                                    metadata = packet_data[3]
+                                    server_time = metadata.get("time", 0) if isinstance(metadata, dict) else 0
+                                    if server_time > 0:
+                                        if hasattr(self, "_last_server_time") and self._last_server_time > 0:
+                                            send_diff = server_time - self._last_server_time
+                                            arrival_diff = now_ms - self._last_arrival_ms
+                                            if 5 < send_diff < 2000:
+                                                collector.network_jitter.append(max(0.0, arrival_diff - send_diff))
+                                        self._last_server_time = server_time
+                                        self._last_arrival_ms = now_ms
+                        except Exception as e:
+                            if not hasattr(self, '_decode_err_shown'):
+                                self._decode_err_shown = True
+                                print(f"  decode error: {e} (header: {buf[:8].hex()}, comp={buf[2]}, idx={pkt_index}, size={data_size})")
+                    buf = buf[total:]
+                # prepend any remaining partial packet back (new data may
+                # have arrived while we were parsing)
+                if buf:
+                    if sq_lock:
+                        with sq_lock:
+                            sq[stream_id] = buf + sq[stream_id]
+                    else:
+                        sq[stream_id] = buf + sq[stream_id]
+            return True  # keep timer running
+
+        def _hook_quic_timing(self):
+            """Wrap put_raw_substream_data to timestamp QUIC-level arrivals."""
+            proto = getattr(self, "_protocol", None)
+            conn = proto and proto._conn
+            if not conn or not hasattr(conn, "put_raw_substream_data"):
+                print("  (no QUIC substream timing — not a QUIC connection)")
+                return
+            original_put = conn.put_raw_substream_data
+
+            def timed_put(data, stream_id=1):
+                # label by stream_id — the log output shows which id is which type
+                quic_collector.record(f"quic:stream-{stream_id}", len(data))
+                return original_put(data, stream_id)
+
+            conn.put_raw_substream_data = timed_put
+            print(f"  QUIC substream timing hooked on {conn}")
+
+        def _stop_collecting(self):
+            if hasattr(self, '_drain_timer') and self._drain_timer:
+                GLib.source_remove(self._drain_timer)
+                self._drain_timer = 0
+            # drain any remaining data
+            self._drain_substreams()
+            collector.stop()
+            quic_collector.stop()
+            print(f"  Done. Disconnecting...")
+            self.quit(0)
+            return False
+
+        def _ack_packet(self, ptype, packet):
+            """Ack draws, echo pings, map windows.
+
+            Must run on EVERY packet regardless of timing mode — if draws
+            go unacked the server throttles via damage_ack_pending backlog.
+            """
+            if ptype == "ping":
+                echotime = packet[1] if len(packet) > 1 else 0
+                self.send("ping_echo", echotime, 0, 0, 0, -1)
+            elif ptype == "draw":
+                wid = packet[1] if len(packet) > 1 else 0
+                width = packet[4] if len(packet) > 4 else 0
+                height = packet[5] if len(packet) > 5 else 0
+                packet_sequence = packet[8] if len(packet) > 8 else 0
+                self.send("damage-sequence", packet_sequence, wid, width, height, 1, "")
+            elif ptype in ("new-window", "new-override-redirect"):
+                wid = packet[1] if len(packet) > 1 else 0
+                x = packet[2] if len(packet) > 2 else 0
+                y = packet[3] if len(packet) > 3 else 0
+                w = packet[4] if len(packet) > 4 else 100
+                h = packet[5] if len(packet) > 5 else 100
+                self.send("map-window", wid, x, y, w, h)
+
+        def process_packet(self, proto, packet):
+            ptype = str(packet[0]) if len(packet) > 0 else ""
+
+            # always ack, even before timing mode starts
+            self._ack_packet(ptype, packet)
+
+            if not getattr(self, "_timing_mode", False):
+                return super().process_packet(proto, packet)
+
+            # estimate packet size
+            size = sum(
+                len(x) if isinstance(x, (bytes, bytearray, memoryview)) else 8
+                for x in packet
+            )
+            collector.record(ptype, size)
+
+            # for sound-data, compute network jitter from server timestamp
+            # D = arrival_diff - send_diff isolates network transit variation
+            # from server-side scheduling jitter (GLib batching)
+            if ptype == "sound-data" and len(packet) > 3:
+                now_ms = time.monotonic() * 1000
+                try:
+                    metadata = packet[3]
+                    server_time = metadata.get("time", 0) if isinstance(metadata, dict) else 0
+                    if server_time > 0:
+                        if hasattr(self, "_last_server_time") and self._last_server_time > 0:
+                            send_diff = server_time - self._last_server_time
+                            arrival_diff = now_ms - self._last_arrival_ms
+                            if 5 < send_diff < 2000:
+                                collector.network_jitter.append(max(0.0, arrival_diff - send_diff))
+                        self._last_server_time = server_time
+                        self._last_arrival_ms = now_ms
+                except Exception:
+                    pass
+
+    mode_str = "multi-stream" if substreams else "single-stream"
+    print(f"\nConnecting to {url} ({mode_str})...")
+
+    app = TimingClient(opts)
+    display_desc = do_pick_display(
+        lambda msg: sys.exit(msg), opts, [url], [sys.argv[0], url]
+    )
+    app.display_desc = display_desc
+
+    try:
+        connect_to_server(app, display_desc, opts)
+        app.run()
+    except (KeyboardInterrupt, SystemExit):
+        pass
+    finally:
+        try:
+            app.cleanup()
+        except Exception:
+            pass
+
+    return collector, quic_collector
+
+
+def _run_worker(url, password, duration, substreams, sync_interval, result_dict, key):
+    """Worker function for multiprocessing parallel runs."""
+    c, qc = run_test(url, password, duration, substreams=substreams, sync_interval=sync_interval)
+    # PacketTimingCollector uses defaultdict — pickle-safe
+    result_dict[key] = (c, qc)
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="QUIC HOL blocking test",
+        epilog="Generate draw traffic (e.g., glxgears) on the display before running.",
+    )
+    parser.add_argument("url", help="xpra server (e.g., host:10000 or quic://host:10000/)")
+    parser.add_argument("--duration", type=float, default=10,
+                        help="seconds per test pass (default: 10)")
+    parser.add_argument("--password", default="",
+                        help="authentication password")
+    parser.add_argument("--single-only", action="store_true",
+                        help="only run single-stream test")
+    parser.add_argument("--multi-only", action="store_true",
+                        help="only run multi-stream test")
+    parser.add_argument("--parallel", action="store_true",
+                        help="run all modes simultaneously (requires --sharing=yes on server)")
+    parser.add_argument("--sync", type=int, default=0, metavar="SECONDS",
+                        help="wait until next N-second clock boundary before collecting "
+                             "(use same value in both instances for simultaneous A/B)")
+    args = parser.parse_args()
+
+    args.url = _normalize_url(args.url)
+    if args.parallel:
+        _run_parallel(args)
+    else:
+        _run_sequential(args)
+
+
+def _normalize_url(url: str) -> str:
+    """Normalize bare host:port to quic://host:port/"""
+    if "://" not in url:
+        url = f"quic://{url}/"
+    return url
+
+
+def _run_parallel(args):
+    """Run all modes simultaneously using multiprocessing."""
+    from multiprocessing import Process, Manager
+
+    quic_url = _normalize_url(args.url)
+    tcp_url = quic_url.replace("quic://", "tcp://", 1)
+
+    # use 30-second sync boundary so all processes start collecting together
+    sync = args.sync or 30
+
+    manager = Manager()
+    results = manager.dict()
+
+    modes = []
+    if not args.multi_only:
+        modes.append(("tcp", tcp_url, False, sync))
+        modes.append(("quic-single", quic_url, False, sync))
+    if not args.single_only:
+        modes.append(("quic-multi", quic_url, True, sync))
+
+    processes = []
+    for key, url, substreams, sync_val in modes:
+        p = Process(target=_run_worker,
+                    args=(url, args.password, args.duration, substreams, sync_val, results, key))
+        p.start()
+        processes.append((key, p))
+
+    for key, p in processes:
+        p.join()
+
+    # report results
+    for key, _, _, _ in modes:
+        if key in results:
+            c, qc = results[key]
+            c.report(key)
+            if qc.arrivals:
+                qc.report(f"{key} — QUIC arrival")
+
+    # comparison table
+    all_keys = [key for key, _, _, _ in modes if key in results]
+    if len(all_keys) >= 2:
+        _print_parallel_comparison({k: results[k][0] for k in all_keys}, all_keys)
+
+
+def _run_sequential(args):
+    """Run modes one at a time (original behavior)."""
+    results = {}
+    quic_results = {}
+
+    if not args.multi_only:
+        c, qc = run_test(args.url, args.password, args.duration, substreams=False, sync_interval=args.sync)
+        c.report("Single-stream — parse thread")
+        if qc.arrivals:
+            qc.report("Single-stream — QUIC arrival")
+        results["single"] = c
+        quic_results["single"] = qc
+
+    if not args.single_only:
+        if not args.multi_only:
+            print("\n--- waiting 2s before next test ---")
+            time.sleep(2)
+        c, qc = run_test(args.url, args.password, args.duration, substreams=True, sync_interval=args.sync)
+        c.report("Multi-stream — parse thread")
+        if qc.arrivals:
+            qc.report("Multi-stream — QUIC arrival")
+        results["multi"] = c
+        quic_results["multi"] = qc
+
+    _print_comparison(results, "Parse thread")
+    _print_comparison(quic_results, "QUIC arrival")
+
+
+def _print_parallel_comparison(results: dict, keys: list[str]):
+    """Print a comparison table across all parallel modes."""
+    # find packet types common to all modes
+    common = None
+    for key in keys:
+        cats = set(results[key].arrivals.keys())
+        common = cats if common is None else common & cats
+    if not common:
+        return
+
+    print(f"\n{'=' * 70}")
+    print(f"  Parallel comparison")
+    print(f"{'=' * 70}")
+
+    for cat in sorted(common):
+        ias = {}
+        for key in keys:
+            ia = results[key].inter_arrival_ms(cat)
+            if len(ia) < 2:
+                continue
+            ias[key] = ia
+        if len(ias) < 2:
+            continue
+
+        print(f"\n  {cat}:")
+        header = "    {:>12s}".format("")
+        for key in keys:
+            if key in ias:
+                header += f"  {key:>14s}"
+        print(header)
+
+        for metric_name, metric_fn in [
+            ("p95", lambda ia: sorted(ia)[int(len(ia) * 0.95)]),
+            ("max", lambda ia: max(ia)),
+            ("jitter", lambda ia: statistics.stdev(ia)),
+        ]:
+            row = f"    {metric_name:>12s}"
+            for key in keys:
+                if key in ias:
+                    val = metric_fn(ias[key])
+                    row += f"  {val:>12.1f}ms"
+            print(row)
+
+    # network jitter comparison (sound only)
+    nj_data = {k: results[k].network_jitter for k in keys if results[k].network_jitter}
+    if len(nj_data) >= 2:
+        print(f"\n  sound network jitter (arrival_diff - send_diff):")
+        active_keys = [k for k in keys if k in nj_data]
+        header = "    {:>12s}".format("")
+        for key in active_keys:
+            header += f"  {key:>14s}"
+        print(header)
+        for metric_name, metric_fn in [
+            ("p95", lambda nj: sorted(nj)[int(len(nj) * 0.95)]),
+            ("max", lambda nj: max(nj)),
+            ("stdev", lambda nj: statistics.stdev(nj)),
+        ]:
+            row = f"    {metric_name:>12s}"
+            for key in active_keys:
+                val = metric_fn(nj_data[key])
+                row += f"  {val:>12.1f}ms"
+            print(row)
+
+
+def _print_comparison(results: dict, label: str):
+    if "single" not in results or "multi" not in results:
+        return
+    common = sorted(
+        set(results["single"].arrivals.keys()) & set(results["multi"].arrivals.keys())
+    )
+    if not common:
+        return
+    print(f"\n{'=' * 60}")
+    print(f"  Comparison — {label}")
+    print(f"{'=' * 60}")
+    for cat in common:
+        s_ia = results["single"].inter_arrival_ms(cat)
+        m_ia = results["multi"].inter_arrival_ms(cat)
+        if len(s_ia) < 2 or len(m_ia) < 2:
+            continue
+        s_p95 = sorted(s_ia)[int(len(s_ia) * 0.95)]
+        m_p95 = sorted(m_ia)[int(len(m_ia) * 0.95)]
+        s_max = max(s_ia)
+        m_max = max(m_ia)
+        s_jitter = statistics.stdev(s_ia)
+        m_jitter = statistics.stdev(m_ia)
+        p95_change = ((s_p95 - m_p95) / s_p95 * 100) if s_p95 > 0 else 0
+        max_change = ((s_max - m_max) / s_max * 100) if s_max > 0 else 0
+        jitter_change = ((s_jitter - m_jitter) / s_jitter * 100) if s_jitter > 0 else 0
+        print(f"\n  {cat}:")
+        print(f"    p95:    {s_p95:.1f}ms -> {m_p95:.1f}ms ({p95_change:+.0f}%)")
+        print(f"    max:    {s_max:.1f}ms -> {m_max:.1f}ms ({max_change:+.0f}%)")
+        print(f"    jitter: {s_jitter:.1f}ms -> {m_jitter:.1f}ms ({jitter_change:+.0f}%)")
+
+
+if __name__ == "__main__":
+    # required for multiprocessing on Windows (spawn) and cx_Freeze
+    import multiprocessing
+    multiprocessing.freeze_support()
+    main()

--- a/tests/unittests/unit/net/quic_stream_priority_test.py
+++ b/tests/unittests/unit/net/quic_stream_priority_test.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+# This file is part of Xpra.
+# Copyright (C) 2026 Netflix, Inc.
+# Xpra is released under the terms of the GNU GPL v2, or, at your option, any
+# later version. See the file COPYING for details.
+
+# ABOUTME: Tests for QUIC stream prioritization — verifies that _prioritize_streams
+# ABOUTME: reorders aioquic's internal stream dict to send realtime data first.
+
+import unittest
+from unittest.mock import MagicMock, PropertyMock
+
+
+class FakeQuicStream:
+    """Minimal stand-in for aioquic QuicStream."""
+    def __init__(self, stream_id):
+        self.stream_id = stream_id
+
+
+class TestPrioritizeStreams(unittest.TestCase):
+    """Test that _prioritize_streams reorders the aioquic stream dict correctly."""
+
+    def _make_connection(self, stream_ids_in_order):
+        """Create an XpraQuicConnection with a fake _quic._streams dict."""
+        from xpra.net.quic.connection import XpraQuicConnection
+        conn = object.__new__(XpraQuicConnection)
+        # minimal init for the fields _prioritize_streams touches
+        conn.stream_id = 0  # main WebSocket stream
+        conn._packet_type_streams = {}
+        conn._substream_ids = set()
+        # fake the aioquic connection with a _streams dict
+        mock_h3 = MagicMock()
+        mock_quic = MagicMock()
+        mock_quic._streams = {sid: FakeQuicStream(sid) for sid in stream_ids_in_order}
+        mock_h3._quic = mock_quic
+        conn.connection = mock_h3
+        return conn, mock_quic._streams
+
+    def test_no_substreams(self):
+        """With no substreams allocated, order stays unchanged."""
+        conn, streams = self._make_connection([0, 2, 6])
+        conn._prioritize_streams()
+        self.assertEqual(list(streams.keys()), [0, 2, 6])
+
+    def test_sound_before_draw(self):
+        """Sound substream sorts before draw substream."""
+        # simulate: main=0, draw=4, sound=8 (draw allocated before sound)
+        conn, streams = self._make_connection([0, 2, 4, 8])
+        conn._substream_ids = {4, 8}
+        conn._packet_type_streams = {"draw": 4, "sound": 8}
+        conn._prioritize_streams()
+        order = list(streams.keys())
+        sound_idx = order.index(8)
+        draw_idx = order.index(4)
+        self.assertLess(sound_idx, draw_idx,
+                        f"sound (stream 8) should come before draw (stream 4), got {order}")
+
+    def test_main_stream_first(self):
+        """Main/control streams always come before substreams."""
+        conn, streams = self._make_connection([0, 2, 4, 8])
+        conn._substream_ids = {4, 8}
+        conn._packet_type_streams = {"sound": 4, "draw": 8}
+        conn._prioritize_streams()
+        order = list(streams.keys())
+        # main stream (0) and H3 control (2) should be first
+        self.assertEqual(order[0], 0)
+        self.assertEqual(order[1], 2)
+
+    def test_input_before_sound(self):
+        """Client-side: key and pointer streams sort before sound."""
+        conn, streams = self._make_connection([0, 2, 4, 8, 12])
+        conn._substream_ids = {4, 8, 12}
+        conn._packet_type_streams = {"sound": 4, "key": 8, "pointer": 12}
+        conn._prioritize_streams()
+        order = list(streams.keys())
+        key_idx = order.index(8)
+        pointer_idx = order.index(12)
+        sound_idx = order.index(4)
+        self.assertLess(key_idx, sound_idx,
+                        f"key should come before sound, got {order}")
+        self.assertLess(pointer_idx, sound_idx,
+                        f"pointer should come before sound, got {order}")
+
+    def test_full_priority_order(self):
+        """All stream types sort in the expected STREAM_PRIORITY order."""
+        from xpra.net.quic.connection import STREAM_PRIORITY
+        conn, streams = self._make_connection([0, 4, 8, 12, 16, 20])
+        conn._substream_ids = {4, 8, 12, 16, 20}
+        conn._packet_type_streams = {
+            "draw": 4,
+            "webcam": 8,
+            "sound": 12,
+            "pointer": 16,
+            "key": 20,
+        }
+        conn._prioritize_streams()
+        order = list(streams.keys())
+        # main stream first
+        self.assertEqual(order[0], 0)
+        # then substreams in STREAM_PRIORITY order: key, pointer, sound, webcam, draw
+        substream_order = order[1:]
+        expected_types = list(STREAM_PRIORITY)
+        actual_types = []
+        type_by_sid = {v: k for k, v in conn._packet_type_streams.items()}
+        for sid in substream_order:
+            actual_types.append(type_by_sid[sid])
+        self.assertEqual(actual_types, expected_types,
+                         f"substream order should match STREAM_PRIORITY, got {actual_types}")
+
+    def test_idempotent(self):
+        """Calling _prioritize_streams twice gives the same result."""
+        conn, streams = self._make_connection([0, 2, 4, 8])
+        conn._substream_ids = {4, 8}
+        conn._packet_type_streams = {"draw": 4, "sound": 8}
+        conn._prioritize_streams()
+        order1 = list(streams.keys())
+        conn._prioritize_streams()
+        order2 = list(streams.keys())
+        self.assertEqual(order1, order2)
+
+    def test_no_quic_attribute(self):
+        """Gracefully handles missing _quic attribute (e.g., H0 connection)."""
+        conn, _ = self._make_connection([0])
+        conn.connection = MagicMock(spec=[])  # no _quic attribute
+        # should not raise
+        conn._prioritize_streams()
+
+
+class TestAllocateSubstreamCallsPrioritize(unittest.TestCase):
+    """Verify that _allocate_substream triggers _prioritize_streams."""
+
+    def test_prioritize_called_on_allocate(self):
+        from xpra.net.quic.connection import XpraQuicConnection
+        conn = object.__new__(XpraQuicConnection)
+        conn.stream_id = 0
+        conn._packet_type_streams = {}
+        conn._substream_ids = set()
+        conn._pending_substreams = set()
+        conn._use_substreams = True
+        conn._substream_packet_types = ("sound", "draw")
+        conn._register_substream = None
+        conn.closed = False
+        # fake quic
+        mock_h3 = MagicMock()
+        mock_quic = MagicMock()
+        mock_quic.get_next_available_stream_id.return_value = 4
+        mock_quic._streams = {0: FakeQuicStream(0)}
+        mock_h3._quic = mock_quic
+        conn.connection = mock_h3
+        # spy on _prioritize_streams
+        calls = []
+        original = conn._prioritize_streams
+        def spy():
+            calls.append(True)
+            original()
+        conn._prioritize_streams = spy
+        conn._allocate_substream("sound")
+        self.assertEqual(len(calls), 1, "_prioritize_streams should be called once")
+        self.assertIn(4, conn._substream_ids)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittests/unit/net/quic_tls_error_test.py
+++ b/tests/unittests/unit/net/quic_tls_error_test.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+# This file is part of Xpra.
+# Copyright (C) 2026 Netflix, Inc.
+# Xpra is released under the terms of the GNU GPL v2, or, at your option, any
+# later version. See the file COPYING for details.
+
+# ABOUTME: Tests for QUIC TLS error surfacing — verifies that TLS errors during
+# ABOUTME: QUIC handshake are caught and formatted as actionable user messages.
+
+import asyncio
+import unittest
+from unittest.mock import patch
+
+from xpra.exit_codes import ExitCode
+
+
+class TestFormatTLSError(unittest.TestCase):
+    """Test that TLS/OpenSSL exceptions are mapped to user-friendly messages."""
+
+    def test_openssl_no_such_file(self):
+        from xpra.net.quic.client import format_tls_error
+        # simulate the OpenSSL error from a missing CA bundle
+        try:
+            from OpenSSL.crypto import Error as OpenSSLError
+        except ImportError:
+            raise unittest.SkipTest("pyOpenSSL not available")
+        err = OpenSSLError([
+            ("system library", "", ""),
+            ("BIO routines", "", "no such file"),
+            ("x509 certificate routines", "", "BIO lib"),
+        ])
+        exit_code, msg = format_tls_error(err)
+        self.assertEqual(exit_code, ExitCode.SSL_FAILURE)
+        self.assertIn("CA certificate", msg)
+
+    def test_openssl_certificate_verify_failed(self):
+        from xpra.net.quic.client import format_tls_error
+        try:
+            from OpenSSL.crypto import Error as OpenSSLError
+        except ImportError:
+            raise unittest.SkipTest("pyOpenSSL not available")
+        err = OpenSSLError([
+            ("x509 certificate routines", "", "certificate verify failed"),
+        ])
+        exit_code, msg = format_tls_error(err)
+        self.assertEqual(exit_code, ExitCode.SSL_CERTIFICATE_VERIFY_FAILURE)
+        self.assertIn("certificate verify failed", msg.lower())
+
+    def test_openssl_hostname_mismatch(self):
+        from xpra.net.quic.client import format_tls_error
+        try:
+            from OpenSSL.crypto import Error as OpenSSLError
+        except ImportError:
+            raise unittest.SkipTest("pyOpenSSL not available")
+        err = OpenSSLError([
+            ("x509 certificate routines", "", "hostname mismatch"),
+        ])
+        exit_code, msg = format_tls_error(err)
+        self.assertEqual(exit_code, ExitCode.SSL_CERTIFICATE_VERIFY_FAILURE)
+        self.assertIn("hostname mismatch", msg.lower())
+
+    def test_connection_error_no_message(self):
+        from xpra.net.quic.client import format_tls_error
+        err = ConnectionError()
+        exit_code, msg = format_tls_error(err)
+        self.assertEqual(exit_code, ExitCode.SSL_FAILURE)
+        self.assertIn("handshake", msg.lower())
+
+    def test_generic_exception(self):
+        from xpra.net.quic.client import format_tls_error
+        err = RuntimeError("something went wrong")
+        exit_code, msg = format_tls_error(err)
+        self.assertEqual(exit_code, ExitCode.SSL_FAILURE)
+        self.assertIn("something went wrong", msg)
+
+
+class TestDatagramReceivedErrorCapture(unittest.TestCase):
+    """Test that WebSocketClient.datagram_received catches TLS errors."""
+
+    def _make_protocol(self):
+        from aioquic.quic.configuration import QuicConfiguration
+        from aioquic.quic.connection import QuicConnection
+        from aioquic.h3.connection import H3_ALPN
+        from xpra.net.quic.client import WebSocketClient
+        config = QuicConfiguration(is_client=True, alpn_protocols=H3_ALPN)
+        conn = QuicConnection(configuration=config)
+        return WebSocketClient(conn)
+
+    def test_tls_error_stored_on_protocol(self):
+        """When datagram_received raises, the error is stored on _tls_error."""
+        protocol = self._make_protocol()
+        try:
+            from OpenSSL.crypto import Error as OpenSSLError
+        except ImportError:
+            raise unittest.SkipTest("pyOpenSSL not available")
+        tls_err = OpenSSLError([("x509 certificate routines", "", "certificate verify failed")])
+        # patch the parent datagram_received to simulate a TLS error
+        with patch.object(type(protocol).__mro__[1], "datagram_received", side_effect=tls_err):
+            protocol.datagram_received(b"\x00" * 10, ("127.0.0.1", 10000))
+        self.assertIs(protocol._tls_error, tls_err)
+
+    def test_connected_waiter_resolved_with_error(self):
+        """When datagram_received raises and a waiter exists, it gets the error."""
+        protocol = self._make_protocol()
+        try:
+            from OpenSSL.crypto import Error as OpenSSLError
+        except ImportError:
+            raise unittest.SkipTest("pyOpenSSL not available")
+        tls_err = OpenSSLError([("x509 certificate routines", "", "certificate verify failed")])
+        # set up a connected waiter
+        loop = asyncio.new_event_loop()
+        waiter = loop.create_future()
+        protocol._connected_waiter = waiter
+        with patch.object(type(protocol).__mro__[1], "datagram_received", side_effect=tls_err):
+            protocol.datagram_received(b"\x00" * 10, ("127.0.0.1", 10000))
+        # waiter should have the exception set
+        self.assertTrue(waiter.done())
+        self.assertIs(waiter.exception(), tls_err)
+        self.assertIsNone(protocol._connected_waiter)
+        loop.close()
+
+    def test_no_error_on_normal_datagram(self):
+        """Normal datagrams don't set _tls_error."""
+        protocol = self._make_protocol()
+        with patch.object(type(protocol).__mro__[1], "datagram_received"):
+            protocol.datagram_received(b"\x00" * 10, ("127.0.0.1", 10000))
+        self.assertIsNone(protocol._tls_error)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/xpra/client/base/client.py
+++ b/xpra/client/base/client.py
@@ -559,6 +559,11 @@ class XpraClientBase(PacketDispatcher, ClientBaseClass):
         p.parse_remote_caps(caps)
         self.server_packet_types = caps.strtupleget("packet-types")
         netlog(f"parse_network_capabilities(..) server_packet_types={self.server_packet_types}")
+        # enable client->server QUIC substreams if the server supports them
+        if caps.boolget("quic.substreams"):
+            conn = getattr(p, "_conn", None)
+            if conn and hasattr(conn, "enable_substreams"):
+                conn.enable_substreams()
         return True
 
     def _process_startup_complete(self, packet: Packet) -> None:

--- a/xpra/net/net_util.py
+++ b/xpra/net/net_util.py
@@ -424,6 +424,12 @@ def get_network_caps(full_info: int = 1) -> dict[str, Any]:
         caps["flush"] = FLUSH_HEADER
     caps.update(get_compression_caps(full_info))
     caps.update(get_packet_encoding_caps(full_info))
+    try:
+        from xpra.net.quic.websocket import SUBSTREAM_PACKET_TYPES
+        if SUBSTREAM_PACKET_TYPES:
+            caps["quic.substreams"] = True
+    except ImportError:
+        pass
     return caps
 
 

--- a/xpra/net/protocol/socket_handler.py
+++ b/xpra/net/protocol/socket_handler.py
@@ -1,6 +1,7 @@
 # This file is part of Xpra.
 # Copyright (C) 2011 Antoine Martin <antoine@xpra.org>
 # Copyright (C) 2008 Nathaniel Smith <njs@pobox.com>
+# Copyright (C) 2026 Netflix, Inc.
 # Xpra is released under the terms of the GNU GPL v2, or, at your option, any
 # later version. See the file COPYING for details.
 
@@ -131,7 +132,7 @@ class SocketProtocol:
         self.make_chunk_header: Callable[[str | int, int, int, int, int], bytes] = self.make_xpra_header
         self.make_frame_header: Callable[[str | int, list[SizedBuffer]], SizedBuffer] = self.noframe_header
         self._write_queue: Queue[tuple[Sequence, str, bool, bool] | None] = Queue(1)
-        self._read_queue: Queue[SizedBuffer] = Queue(20)
+        self._read_queue: Queue[tuple[int, SizedBuffer] | None] = Queue(20)
         self._pre_read = []
         self._process_read: Callable[[SizedBuffer], None] = self.read_queue_put
         self._read_queue_put: Callable[[SizedBuffer], None] = self.read_queue_put
@@ -963,9 +964,20 @@ class SocketProtocol:
                 self.idle_add(self.close)
                 return
             self.start_read_parser_thread()
-        self._read_queue.put(data)
+        self._read_queue.put((0, data))
         # from now on, take shortcut:
-        self._read_queue_put = self._read_queue.put
+        self._read_queue_put = self._read_queue_put_shortcut
+
+    def _read_queue_put_shortcut(self, data: SizedBuffer) -> None:
+        self._read_queue.put((0, data))
+
+    def substream_read_queue_put(self, data: SizedBuffer, stream_id: int = 1) -> None:
+        """Deliver data from a QUIC substream with a separate parse context."""
+        if not self._read_parser_thread and not self._closed:
+            if data is None:
+                return
+            self.start_read_parser_thread()
+        self._read_queue.put((stream_id, data))
 
     def start_read_parser_thread(self) -> None:
         with self._threading_lock:
@@ -981,6 +993,25 @@ class SocketProtocol:
                 return
             self._internal_error("error in network packet reading/parsing", e, exc_info=True)
 
+    class ParseState:
+        """Per-stream packet reassembly state for the parse thread."""
+        __slots__ = (
+            "header", "read_buffers", "payload_size", "padding_size",
+            "packet_index", "protocol_flags", "data_size", "compression_level",
+            "raw_packets",
+        )
+
+        def __init__(self):
+            self.header: bytes = b""
+            self.read_buffers: list[SizedBuffer] = []
+            self.payload_size: int = -1
+            self.padding_size: int = 0
+            self.packet_index: int = 0
+            self.protocol_flags: int = 0
+            self.data_size: int = 0
+            self.compression_level: int = 0
+            self.raw_packets: dict[int, SizedBuffer] = {}
+
     def do_read_parse_thread_loop(self) -> None:
         """
             Process the individual network packets placed in _read_queue.
@@ -992,98 +1023,112 @@ class SocketProtocol:
             The actual processing of the packet is done via the callback process_packet_cb,
             this will be called from this parsing thread so any calls that need to be made
             from the UI thread will need to use a callback (usually via 'idle_add')
+
+            Queue entries are (stream_id, data) tuples. Each stream maintains
+            independent parse state so that data from QUIC substreams does not
+            interleave with the main WebSocket stream during packet reassembly.
         """
-        header = b""
-        read_buffers: list[SizedBuffer] = []
-        payload_size = -1
-        padding_size = 0
-        packet_index = 0
-        protocol_flags = 0
-        data_size = 0
-        compression_level = 0
-        raw_packets: dict[int, SizedBuffer] = {}
+        # per-stream parse state, keyed by stream ID (0 = main stream)
+        streams: dict[int, SocketProtocol.ParseState] = {0: self.ParseState()}
         while not self._closed:
-            # log("parse thread: %i items in read queue", self._read_queue.qsize())
-            buf = self._read_queue.get()
+            entry = self._read_queue.get()
+            if not entry:
+                eventlog("parse thread: empty marker, exiting")
+                self.idle_add(self.close)
+                return
+
+            # unpack tagged entry: (stream_id, data)
+            if isinstance(entry, tuple) and len(entry) == 2 and isinstance(entry[0], int):
+                stream_id, buf = entry
+            else:
+                # backward compatibility: untagged entry is main stream
+                stream_id, buf = 0, entry
+
             if not buf:
                 eventlog("parse thread: empty marker, exiting")
                 self.idle_add(self.close)
                 return
 
-            read_buffers.append(buf)
-            if self.wait_for_header:
+            # get or create parse state for this stream
+            s = streams.get(stream_id)
+            if s is None:
+                s = self.ParseState()
+                streams[stream_id] = s
+
+            s.read_buffers.append(buf)
+            if self.wait_for_header and stream_id == 0:
                 # we're waiting to see the first xpra packet header
                 # which may come after some random characters
                 # (ie: when connecting over ssh, the channel may contain some unexpected output)
                 # for this to work, we have to assume that the initial packet is smaller than 64KB:
-                joined = b"".join(read_buffers)
+                joined = b"".join(s.read_buffers)
                 pos = find_xpra_header(joined)
                 eventlog("waiting for xpra header: pos=%i", pos)
                 if pos < 0:
                     # wait some more:
-                    read_buffers = [joined]
+                    s.read_buffers = [joined]
                     continue
                 # found it, so proceed:
-                read_buffers = [joined[pos:]]
+                s.read_buffers = [joined[pos:]]
                 self.wait_for_header = False
 
-            while read_buffers:
+            while s.read_buffers:
                 # have we read the header yet?
-                if payload_size < 0:
+                if s.payload_size < 0:
                     # try to handle the first buffer:
-                    buf = read_buffers[0]
-                    if not header and buf[0] != PACKET_HEADER_CHAR:
+                    buf = s.read_buffers[0]
+                    if not s.header and buf[0] != PACKET_HEADER_CHAR:
                         self.invalid_header(self, buf, f"invalid packet header byte {hex(buf[0])}")
                         return
                     # how much to we need to slice off to complete the header:
-                    read = min(len(buf), HEADER_SIZE - len(header))
-                    header += memoryview_to_bytes(buf[:read])
-                    if len(header) < HEADER_SIZE:
+                    read = min(len(buf), HEADER_SIZE - len(s.header))
+                    s.header += memoryview_to_bytes(buf[:read])
+                    if len(s.header) < HEADER_SIZE:
                         # need to process more buffers to get a full header:
-                        read_buffers.pop(0)
+                        s.read_buffers.pop(0)
                         continue
                     if len(buf) <= read:
                         # we only got the header:
                         assert len(buf) == read
-                        read_buffers.pop(0)
+                        s.read_buffers.pop(0)
                         continue
                     # got the full header and more, keep the rest of the packet:
-                    read_buffers[0] = buf[read:]
+                    s.read_buffers[0] = buf[read:]
                     # parse the header:
                     # format: struct.pack(b'cBBBL', ...) - HEADER_SIZE bytes
-                    _, protocol_flags, compression_level, packet_index, data_size = unpack_header(header)
+                    _, s.protocol_flags, s.compression_level, s.packet_index, s.data_size = unpack_header(s.header)
 
                     # sanity check size (will often fail if not an xpra client):
-                    if data_size > self.abs_max_packet_size:
-                        self.invalid_header(self, header, f"invalid size in packet header: {data_size}")
+                    if s.data_size > self.abs_max_packet_size:
+                        self.invalid_header(self, s.header, f"invalid size in packet header: {s.data_size}")
                         return
 
-                    if packet_index >= 16:
-                        self.invalid_header(self, header, f"invalid packet index: {packet_index}")
+                    if s.packet_index >= 16:
+                        self.invalid_header(self, s.header, f"invalid packet index: {s.packet_index}")
                         return
 
-                    if protocol_flags & FLAGS_CIPHER:
+                    if s.protocol_flags & FLAGS_CIPHER:
                         if not self.cipher_in_name:
                             cryptolog.warn("Warning: received cipher block,")
                             cryptolog.warn(" but we don't have a cipher to decrypt it with,")
                             cryptolog.warn(" not an xpra client?")
-                            self.invalid_header(self, header, "invalid encryption packet flag (no cipher configured)")
+                            self.invalid_header(self, s.header, "invalid encryption packet flag (no cipher configured)")
                             return
                         if self.cipher_in_block_size == 0:
-                            padding_size = 0
+                            s.padding_size = 0
                         else:
-                            padding_size = self.cipher_in_block_size - (data_size % self.cipher_in_block_size)
-                            if self.cipher_in_always_pad and padding_size == 0:
-                                padding_size = self.cipher_in_block_size
-                        payload_size = data_size + padding_size
+                            s.padding_size = self.cipher_in_block_size - (s.data_size % self.cipher_in_block_size)
+                            if self.cipher_in_always_pad and s.padding_size == 0:
+                                s.padding_size = self.cipher_in_block_size
+                        s.payload_size = s.data_size + s.padding_size
                     else:
                         # no cipher, no padding:
-                        padding_size = 0
-                        payload_size = data_size
-                    if payload_size <= 0:
-                        raise ValueError(f"invalid payload size {payload_size} for header {header!r}")
+                        s.padding_size = 0
+                        s.payload_size = s.data_size
+                    if s.payload_size <= 0:
+                        raise ValueError(f"invalid payload size {s.payload_size} for header {s.header!r}")
 
-                    if payload_size > self.max_packet_size:
+                    if s.payload_size > self.max_packet_size:
                         # this packet is seemingly too big, but check again from the main UI thread
                         # this gives 'set_max_packet_size' a chance to run from "hello"
 
@@ -1099,54 +1144,54 @@ class SocketProtocol:
                                 self.invalid(err_msg, packet_header)
                             return False
 
-                        self.timeout_add(1000, check_packet_size, payload_size, header)
+                        self.timeout_add(1000, check_packet_size, s.payload_size, s.header)
 
                 # how much data do we have?
-                bl = sum(len(v) for v in read_buffers)
-                if bl < payload_size:
+                bl = sum(len(v) for v in s.read_buffers)
+                if bl < s.payload_size:
                     # incomplete packet, wait for the rest to arrive
                     break
 
                 raw_data: SizedBuffer
-                buf = read_buffers[0]
-                if len(buf) == payload_size:
+                buf = s.read_buffers[0]
+                if len(buf) == s.payload_size:
                     # exact match, consume it all:
-                    raw_data = read_buffers.pop(0)
-                elif len(buf) > payload_size:
+                    raw_data = s.read_buffers.pop(0)
+                elif len(buf) > s.payload_size:
                     # keep rest of packet for later:
-                    read_buffers[0] = buf[payload_size:]
-                    raw_data = buf[:payload_size]
+                    s.read_buffers[0] = buf[s.payload_size:]
+                    raw_data = buf[:s.payload_size]
                 else:
                     # we need to aggregate chunks,
                     # just concatenate them all:
-                    raw_data = b"".join(read_buffers)
-                    if bl == payload_size:
+                    raw_data = b"".join(s.read_buffers)
+                    if bl == s.payload_size:
                         # nothing left:
-                        read_buffers = []
+                        s.read_buffers = []
                     else:
                         # keep the left over:
-                        read_buffers = [raw_data[payload_size:]]
-                        raw_data = raw_data[:payload_size]
+                        s.read_buffers = [raw_data[s.payload_size:]]
+                        raw_data = raw_data[:s.payload_size]
 
                 data = raw_data
                 # decrypt if needed:
                 if self.cipher_in_name:
-                    if not protocol_flags & FLAGS_CIPHER:
+                    if not s.protocol_flags & FLAGS_CIPHER:
                         self.invalid("unencrypted packet dropped", data)
                         return
-                    data = self.decrypt(raw_data, padding_size)
+                    data = self.decrypt(raw_data, s.padding_size)
                     if not data:
                         return
 
                 # uncompress if needed:
-                if compression_level > 0:
+                if s.compression_level > 0:
                     try:
-                        data = decompress(data, compression_level)
+                        data = decompress(data, s.compression_level)
                     except InvalidCompressionException as e:
                         self.invalid(f"invalid compression: {e}", data)
                         return
                     except Exception as e:
-                        ctype = compression.get_compression_type(compression_level)
+                        ctype = compression.get_compression_type(s.compression_level)
                         msg = f"{ctype} packet decompression failed"
                         log(msg, exc_info=True)
                         if self.cipher_in:
@@ -1164,16 +1209,16 @@ class SocketProtocol:
 
                 # we're processing this packet,
                 # make sure we get a new header next time
-                header = b""
-                if packet_index > 0:
-                    if packet_index in raw_packets:
-                        self.invalid(f"duplicate raw packet at index {packet_index}", data)
+                s.header = b""
+                if s.packet_index > 0:
+                    if s.packet_index in s.raw_packets:
+                        self.invalid(f"duplicate raw packet at index {s.packet_index}", data)
                         return
                     # raw packet, store it and continue:
-                    raw_packets[packet_index] = data
-                    payload_size = -1
-                    if len(raw_packets) >= 4:
-                        self.invalid(f"too many raw packets: {len(raw_packets)}", data)
+                    s.raw_packets[s.packet_index] = data
+                    s.payload_size = -1
+                    if len(s.raw_packets) >= 4:
+                        self.invalid(f"too many raw packets: {len(s.raw_packets)}", data)
                         return
                     # we know for sure that another packet should follow immediately
                     # the one with packet_index=0 for this raw packet
@@ -1181,12 +1226,12 @@ class SocketProtocol:
                     continue
                 # final packet (packet_index==0), decode it:
                 try:
-                    packet = list(decode(data, protocol_flags))
+                    packet = list(decode(data, s.protocol_flags))
                 except InvalidPacketEncodingException as e:
                     self.invalid(f"invalid packet encoding: {e}", data)
                     return
                 except (ValueError, TypeError, IndexError) as e:
-                    etype = packet_encoding.get_packet_encoding_type(protocol_flags)
+                    etype = packet_encoding.get_packet_encoding_type(s.protocol_flags)
                     log.error(f"Error parsing {etype} packet:")
                     log.estr(e)
                     if self._closed:
@@ -1194,7 +1239,7 @@ class SocketProtocol:
                     eventlog(f"failed to parse {etype} packet: %s", hexstr(data[:128]), exc_info=True)
                     data_str = memoryview_to_bytes(data)
                     eventlog(" data: %s", repr_ellipsized(data_str))
-                    eventlog(f" packet_index={packet_index}, payload_size={payload_size}, buffer size={bl}")
+                    eventlog(f" packet_index={s.packet_index}, payload_size={s.payload_size}, buffer size={bl}")
                     eventlog(" full data: %s", hexstr(data_str))
                     self.may_log_stats()
                     self.gibberish(f"failed to parse {etype} packet", data)
@@ -1202,22 +1247,22 @@ class SocketProtocol:
 
                 if self._closed:
                     return
-                payload_size = len(data)
+                total_size = len(data)
                 # add any raw packets back into it:
-                if raw_packets:
-                    for index, raw_data in raw_packets.items():
+                if s.raw_packets:
+                    for index, raw_data in s.raw_packets.items():
                         # replace placeholder with the raw_data packet data:
                         packet[index] = raw_data
-                        payload_size += len(raw_data)
-                    raw_packets = {}
+                        total_size += len(raw_data)
+                    s.raw_packets = {}
 
                 packet_type = str(packet[0])
                 self.input_stats[packet_type] = self.output_stats.get(packet_type, 0) + 1
                 if LOG_RAW_PACKET_SIZE and packet_type != "logging":
-                    log.info(f"received {packet_type:<32}: %i bytes", HEADER_SIZE + payload_size)
-                payload_size = -1
+                    log.info(f"received {packet_type:<32}: %i bytes", HEADER_SIZE + total_size)
+                s.payload_size = -1
                 self.input_packetcount += 1
-                self.receive_pending = bool(protocol_flags & FLAGS_FLUSH)
+                self.receive_pending = bool(s.protocol_flags & FLAGS_FLUSH)
                 log("processing packet %s", packet_type)
                 try:
                     wrapped = Packet(*packet)

--- a/xpra/net/quic/client.py
+++ b/xpra/net/quic/client.py
@@ -89,13 +89,45 @@ WT_HEADERS: dict[str, str] = {
     "user-agent": USER_AGENT,
 }
 
+# route these client->server packet type prefixes to independent QUIC streams
+CLIENT_SUBSTREAM_PACKET_TYPES = tuple(x.strip() for x in os.environ.get(
+    "XPRA_QUIC_CLIENT_SUBSTREAM_PACKET_TYPES",
+    "key-,pointer"
+).split(",") if x.strip())
+
 
 class ClientWebSocketConnection(XpraQuicConnection):
 
     def __init__(self, connection: HttpConnection, stream_id: int, transmit: Callable[[], None],
-                 host: str, port: int, info=None, options=None):
+                 host: str, port: int, info=None, options=None,
+                 register_substream: Callable | None = None):
         super().__init__(connection, stream_id, transmit, host, port, "wss", info, options)
         self.write_buffer = SimpleQueue()
+        # configure client-specific substream packet types
+        self._substream_packet_types = CLIENT_SUBSTREAM_PACKET_TYPES
+        self._register_substream = register_substream
+
+    def enable_substreams(self) -> None:
+        """Enable client->server substreams. Called after server hello confirms support."""
+        if self._substream_packet_types:
+            self._use_substreams = True
+            log.info("enabling client->server QUIC substreams for: %s",
+                     ", ".join(self._substream_packet_types))
+            # pre-allocate streams so the first keystroke/mouse move has no setup delay
+            for prefix in self._substream_packet_types:
+                stream_type = prefix.rstrip("-")
+                self._packet_type_streams[stream_type] = self.stream_id
+                self._pending_substreams.add(stream_type)
+
+            def allocate_pending():
+                if self._pending_substreams:
+                    pending = list(self._pending_substreams)
+                    self._pending_substreams.clear()
+                    for st in pending:
+                        self._allocate_substream(st)
+                    self.transmit()
+
+            get_threaded_loop().call(allocate_pending)
 
     def flush_writes(self) -> None:
         # flush the buffered writes:
@@ -230,11 +262,17 @@ class WebSocketClient(QuicConnectionProtocol):
                 self._connected_waiter = None
                 waiter.set_exception(e)
 
+    def register_substream(self, stream_id: int, handler: ClientWebSocketConnection) -> None:
+        """Register a client-initiated substream so it bypasses H3 processing."""
+        log(f"register_substream({stream_id}, {handler})")
+        self._substream_map[stream_id] = handler
+
     def open(self, host: str, port: int, path: str) -> ClientWebSocketConnection:
         log(f"open({host}, {port}, {path})")
         stream_id = self._quic.get_next_available_stream_id()
         websocket = ClientWebSocketConnection(self._http, stream_id, self.transmit,
-                                              host, port)
+                                              host, port,
+                                              register_substream=self.register_substream)
         self._websockets[stream_id] = websocket
         headers = {
             ":authority": host,

--- a/xpra/net/quic/client.py
+++ b/xpra/net/quic/client.py
@@ -1,5 +1,6 @@
 # This file is part of Xpra.
 # Copyright (C) 2022 Antoine Martin <antoine@xpra.org>
+# Copyright (C) 2026 Netflix, Inc.
 # Xpra is released under the terms of the GNU GPL v2, or, at your option, any
 # later version. See the file COPYING for details.
 
@@ -12,7 +13,8 @@ from typing import Union, cast
 from collections.abc import Callable
 
 from aioquic.quic.configuration import QuicConfiguration
-from aioquic.quic.events import QuicEvent
+from aioquic.quic.connection import stream_is_client_initiated, stream_is_unidirectional
+from aioquic.quic.events import QuicEvent, StreamDataReceived
 from aioquic.quic.packet import QuicErrorCode
 from aioquic.h3.connection import H3_ALPN
 from aioquic.h0.connection import H0Connection
@@ -21,7 +23,6 @@ from aioquic.h3.events import (
     DataReceived,
     H3Event,
     HeadersReceived,
-    PushPromiseReceived,
     WebTransportStreamDataReceived,
 )
 from aioquic.quic.connection import QuicConnection
@@ -106,10 +107,6 @@ class ClientWebSocketConnection(XpraQuicConnection):
                     self.accepted = True
                     self.flush_writes()
             return
-        if isinstance(event, PushPromiseReceived):
-            log(f"PushPromiseReceived: {event}")
-            log(f"PushPromiseReceived headers: {event.headers}")
-            return
         super().http_event_received(event)
 
 
@@ -189,8 +186,9 @@ class WebSocketClient(QuicConnectionProtocol):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self._http: HttpConnection | None = None
-        self._push_types: dict[str, int] = {}
         self._websockets: dict[int, ClientWebSocketConnection] = {}
+        self._substream_map: dict[int, ClientWebSocketConnection] = {}
+        self._substream_buffers: dict[int, bytes] = {}
         if self._quic.configuration.alpn_protocols[0].startswith("hq-"):
             self._http = H0Connection(self._quic)
         else:
@@ -212,33 +210,62 @@ class WebSocketClient(QuicConnectionProtocol):
         self.transmit()
         return websocket
 
+    def _is_server_bidirectional(self, stream_id: int) -> bool:
+        return not stream_is_client_initiated(stream_id) and not stream_is_unidirectional(stream_id)
+
+    def _handle_substream_data(self, event: StreamDataReceived) -> bool:
+        stream_id = event.stream_id
+        # already-registered substream: route directly
+        websocket = self._substream_map.get(stream_id)
+        if websocket:
+            log(f"substream {stream_id}: {len(event.data)} bytes")
+            websocket.put_raw_substream_data(event.data, stream_id)
+            return True
+        # only intercept server-initiated bidirectional streams
+        # (server-initiated unidirectional streams are used by H3 internally)
+        if not self._is_server_bidirectional(stream_id):
+            return False
+        # accumulate until we see the type prefix header ("xpra:<type>\n")
+        buf = self._substream_buffers.get(stream_id, b"") + event.data
+        if b"\n" not in buf:
+            log(f"substream {stream_id}: buffering {len(buf)} bytes, waiting for header")
+            self._substream_buffers[stream_id] = buf
+            return True
+        header, remainder = buf.split(b"\n", 1)
+        self._substream_buffers.pop(stream_id, None)
+        header_str = header.decode()
+        if not header_str.startswith("xpra:"):
+            log.warn(f"Warning: unexpected substream header on stream {stream_id}: {header_str!r}")
+            return False
+        stream_type = header_str[5:]  # strip "xpra:" prefix
+        # find parent websocket (there's only one per connection in practice)
+        websocket = next(iter(self._websockets.values()), None)
+        if not websocket:
+            log.warn(f"Warning: no websocket for substream {stream_id}")
+            return True
+        self._substream_map[stream_id] = websocket
+        log.info(f"new substream {stream_id} for {stream_type!r} packets")
+        if remainder:
+            log(f"substream {stream_id}: delivering {len(remainder)} bytes after header")
+            websocket.put_raw_substream_data(remainder, stream_id)
+        return True
+
     def quic_event_received(self, event: QuicEvent) -> None:
+        # route raw QUIC substreams directly, bypassing H3
+        if isinstance(event, StreamDataReceived) and self._handle_substream_data(event):
+            return
         for http_event in self._http.handle_event(event):
             self.http_event_received(http_event)
 
     def http_event_received(self, event: H3Event) -> None:
-        if not isinstance(event, (HeadersReceived, DataReceived, PushPromiseReceived)):
+        if not isinstance(event, (HeadersReceived, DataReceived)):
             log.warn(f"Warning: unexpected http event type: {event}")
             return
         stream_id = event.stream_id
         websocket: ClientWebSocketConnection | None = self._websockets.get(stream_id)
         if not websocket:
-            # perhaps this is a new substream?
-            sub = -1
-            hdict = {}
-            if isinstance(event, HeadersReceived):
-                hdict = {k.decode(): v.decode() for k, v in event.headers}
-                sub = int(hdict.get("substream", -1))
-            if sub < 0:
-                log.warn(f"Warning: unexpected websocket stream id: {stream_id} in {event}")
-                return
-            websocket = self._websockets.get(sub)
-            if not websocket:
-                log.warn(f"Warning: stream {sub} not found in {self._websockets}")
-                return
-            subtype = hdict.get("stream-type")
-            log.info(f"new quic substream {stream_id} for {subtype} packets")
-            self._websockets[stream_id] = websocket
+            log.warn(f"Warning: unexpected websocket stream id: {stream_id} in {event}")
+            return
         websocket.http_event_received(event)
 
 
@@ -303,6 +330,13 @@ def _make_quic_configuration(ssl_cert: str, ssl_key: str, ssl_key_password: str,
         max_datagram_frame_size=MAX_DATAGRAM_FRAME_SIZE,
     )
     configuration.verify_mode = parse_ssl_verify_mode(ssl_server_verify_mode)
+    if not ssl_ca_certs:
+        try:
+            import certifi
+            ssl_ca_certs = certifi.where()
+            log(f"using certifi CA bundle: {ssl_ca_certs}")
+        except (ImportError, FileNotFoundError):
+            log("certifi not available, no default CA bundle")
     if ssl_ca_certs:
         configuration.load_verify_locations(ssl_ca_certs)
     if ssl_cert:

--- a/xpra/net/quic/client.py
+++ b/xpra/net/quic/client.py
@@ -6,6 +6,7 @@
 
 import re
 import os
+import asyncio
 import socket
 import ipaddress
 from queue import SimpleQueue
@@ -44,6 +45,28 @@ from xpra.log import Logger
 log = Logger("quic")
 
 HttpConnection = Union[H0Connection, H3Connection]
+
+
+def format_tls_error(exc: Exception) -> tuple[int, str]:
+    """Map a TLS/OpenSSL exception to (ExitCode, user-friendly message)."""
+    try:
+        from OpenSSL.crypto import Error as OpenSSLError
+    except ImportError:
+        OpenSSLError = None
+    if OpenSSLError and isinstance(exc, OpenSSLError):
+        # OpenSSL errors are lists of (lib, func, reason) tuples
+        reasons = " ".join(r[2] for r in exc.args[0] if r[2]).strip()
+        if "no such file" in reasons:
+            return ExitCode.SSL_FAILURE, f"SSL CA certificate file not found: {reasons}"
+        if "hostname mismatch" in reasons:
+            return ExitCode.SSL_CERTIFICATE_VERIFY_FAILURE, f"SSL certificate hostname mismatch: {reasons}"
+        if "certificate verify failed" in reasons:
+            return ExitCode.SSL_CERTIFICATE_VERIFY_FAILURE, f"SSL certificate verify failed: {reasons}"
+        return ExitCode.SSL_FAILURE, f"SSL error: {reasons}"
+    msg = str(exc)
+    if not msg or msg == str(type(exc)):
+        return ExitCode.SSL_FAILURE, "SSL handshake failed"
+    return ExitCode.SSL_FAILURE, f"SSL handshake failed: {msg}"
 
 IPV6 = socket.has_ipv6 and envbool("XPRA_IPV6", True)
 PREFER_IPV6 = IPV6 and envbool("XPRA_PREFER_IPV6", POSIX)
@@ -189,10 +212,23 @@ class WebSocketClient(QuicConnectionProtocol):
         self._websockets: dict[int, ClientWebSocketConnection] = {}
         self._substream_map: dict[int, ClientWebSocketConnection] = {}
         self._substream_buffers: dict[int, bytes] = {}
+        self._tls_error: Exception | None = None
         if self._quic.configuration.alpn_protocols[0].startswith("hq-"):
             self._http = H0Connection(self._quic)
         else:
             self._http = H3Connection(self._quic)
+
+    def datagram_received(self, data, addr) -> None:
+        try:
+            super().datagram_received(data, addr)
+        except Exception as e:
+            log("datagram_received TLS error", exc_info=True)
+            self._tls_error = e
+            # resolve the connected waiter so we don't hang until timeout
+            if self._connected_waiter is not None:
+                waiter = self._connected_waiter
+                self._connected_waiter = None
+                waiter.set_exception(e)
 
     def open(self, host: str, port: int, path: str) -> ClientWebSocketConnection:
         log(f"open({host}, {port}, {path})")
@@ -330,13 +366,31 @@ def _make_quic_configuration(ssl_cert: str, ssl_key: str, ssl_key_password: str,
         max_datagram_frame_size=MAX_DATAGRAM_FRAME_SIZE,
     )
     configuration.verify_mode = parse_ssl_verify_mode(ssl_server_verify_mode)
-    if not ssl_ca_certs:
+    if not ssl_ca_certs or ssl_ca_certs == "default":
+        # "default" means "use OS cert store" — handled by ssl.load_default_certs()
+        # for TCP+SSL, but aioquic uses pyOpenSSL which has no equivalent.
+        # Find the CA bundle ourselves instead.
+        # certifi.where() may return a stale build-time path in cx_Freeze frozen
+        # builds, so also check relative to the executable.
+        ssl_ca_certs = ""
+        ca_candidates = []
         try:
             import certifi
-            ssl_ca_certs = certifi.where()
-            log(f"using certifi CA bundle: {ssl_ca_certs}")
-        except (ImportError, FileNotFoundError):
-            log("certifi not available, no default CA bundle")
+            ca_candidates.append(certifi.where())
+        except ImportError:
+            pass
+        # frozen build: cacert.pem is next to the executable in lib/certifi/
+        import sys
+        exe_dir = os.path.dirname(getattr(sys, "executable", ""))
+        if exe_dir:
+            ca_candidates.append(os.path.join(exe_dir, "lib", "certifi", "cacert.pem"))
+        for ca_path in ca_candidates:
+            if ca_path and os.path.exists(ca_path):
+                ssl_ca_certs = ca_path
+                log(f"using CA bundle: {ssl_ca_certs}")
+                break
+        else:
+            log("no CA bundle found, certificate verification may fail")
     if ssl_ca_certs:
         configuration.load_verify_locations(ssl_ca_certs)
     if ssl_cert:
@@ -368,46 +422,53 @@ def _quic_connect(create_protocol, host: str, port: int, path: str, fast_open: b
         sock, local_addr = create_local_socket(af)
         transport, protocol = await tl.loop.create_datagram_endpoint(create_protocol, sock=sock)
         log(f"{transport=}, {protocol=}")
-        protocol = cast(QuicConnectionProtocol, protocol)
+        protocol = cast(WebSocketClient, protocol)
         addr = addr_info[4]  # ie: ('192.168.0.10', 10000)
         log(f"connecting from {pretty_socket(local_addr)} to {pretty_socket(addr)} with {fast_open=}")
         if fast_open:
+            # fast-open: queue handshake, then open() triggers transmit
+            # sending ClientHello + websocket headers together
             protocol.connect(addr, transmit=False)
+            conn = protocol.open(host, port, path)
         else:
             protocol.connect(addr)
+        from xpra.scripts.main import CONNECT_TIMEOUT
         log("awaiting connected state")
         try:
-            if not fast_open:
-                await protocol.wait_connected()
-            else:
-                from xpra.scripts.main import CONNECT_TIMEOUT
-                tl.call_later(CONNECT_TIMEOUT, verify_connected, protocol)
-            log(f"{protocol}.open({host!r}, {port}, {path!r})")
-            conn = protocol.open(host, port, path)
-            log(f"quic connection {conn}")
-            return conn
+            # check for TLS errors that arrived before we started waiting
+            if protocol._tls_error:
+                raise protocol._tls_error
+            await asyncio.wait_for(protocol.wait_connected(), timeout=CONNECT_TIMEOUT)
+        except asyncio.TimeoutError:
+            # check if a TLS error was captured before the timeout
+            if protocol._tls_error:
+                exit_code, msg = format_tls_error(protocol._tls_error)
+                raise InitExit(exit_code, msg) from None
+            raise InitExit(ExitCode.CONNECTION_FAILED, "connection timed out") from None
         except Exception as e:
             log("connect()", exc_info=True)
-            # try to get a more meaningful exception message:
-            einfo = str(e)
-            if not einfo:
-                quic_conn = getattr(protocol, "_quic", None)
-                if quic_conn:
-                    close_event = getattr(quic_conn, "_close_event", None)
-                    log(f"{close_event=}, {dir(close_event)}")
-                    if close_event:
-                        err = close_event.error_code
-                        msg = close_event.reason_phrase
-                        if err & QuicErrorCode.CRYPTO_ERROR:
-                            raise InitExit(ExitCode.CONNECTION_FAILED, msg)
-                        # if (err & 0xFF)==QuicErrorCode.CONNECTION_REFUSED:
-                        #    raise InitExit(ExitCode.CONNECTION_FAILED, msg)
-                        raise RuntimeError(close_event.reason_phrase) from None
-            raise RuntimeError(str(e)) from None
+            # prefer the TLS error captured by datagram_received
+            if protocol._tls_error:
+                exit_code, msg = format_tls_error(protocol._tls_error)
+                raise InitExit(exit_code, msg) from None
+            # check for server-initiated CRYPTO_ERROR in the close event
+            close_event = getattr(protocol._quic, "_close_event", None)
+            if close_event:
+                err = close_event.error_code
+                msg = close_event.reason_phrase
+                if err & QuicErrorCode.CRYPTO_ERROR:
+                    raise InitExit(ExitCode.SSL_CERTIFICATE_VERIFY_FAILURE,
+                                   msg or "SSL certificate verification rejected by server") from None
+                if msg:
+                    raise InitExit(ExitCode.CONNECTION_FAILED, msg) from None
+            exit_code, msg = format_tls_error(e)
+            raise InitExit(exit_code, msg) from None
+        if not fast_open:
+            log(f"{protocol}.open({host!r}, {port}, {path!r})")
+            conn = protocol.open(host, port, path)
+        log(f"websocket connection {conn}")
+        return conn
 
-    # protocol.close()
-    # await protocol.wait_closed()
-    # transport.close()
     if len(addresses) == 1:
         return tl.sync(connect, addresses[0])
 
@@ -423,6 +484,7 @@ def _quic_connect(create_protocol, host: str, port: int, path: str, fast_open: b
     raise InitExit(ExitCode.CONNECTION_FAILED, "failed to connect: " + csv(errors))
 
 
+
 def quic_connect(host: str, port: int, path: str, fast_open: bool,
                  ssl_cert: str, ssl_key: str, ssl_key_password: str,
                  ssl_ca_certs, ssl_server_verify_mode: str, ssl_server_name: str,
@@ -435,10 +497,3 @@ def quic_connect(host: str, port: int, path: str, fast_open: bool,
         return client_class(QuicConnection(configuration=configuration))
 
     return _quic_connect(create_protocol, host, port, path, fast_open)
-
-
-def verify_connected(protocol) -> None:
-    # this is only useful for debugging,
-    # as we have no way to send a message to the main thread,
-    # I guess it may still show up in some debug log?
-    log("verify_connect(%s) connected=%s", protocol, protocol._connected)

--- a/xpra/net/quic/connection.py
+++ b/xpra/net/quic/connection.py
@@ -1,5 +1,6 @@
 # This file is part of Xpra.
 # Copyright (C) 2022 Antoine Martin <antoine@xpra.org>
+# Copyright (C) 2026 Netflix, Inc.
 # Xpra is released under the terms of the GNU GPL v2, or, at your option, any
 # later version. See the file COPYING for details.
 
@@ -49,6 +50,13 @@ class XpraQuicConnection(Connection):
         self.transmit: Callable[[], None] = transmit
         self.accepted: bool = False
         self.closed: bool = False
+        # substream send infrastructure (configured by subclasses)
+        self._packet_type_streams: dict[str, int] = {}
+        self._substream_ids: set[int] = set()
+        self._pending_substreams: set[str] = set()
+        self._use_substreams: bool = False
+        self._substream_packet_types: tuple[str, ...] = ()
+        self._register_substream: Callable | None = None
 
     def __repr__(self):
         return f"XpraQuicConnection<{self.socktype}:{self.stream_id}>"
@@ -145,10 +153,75 @@ class XpraQuicConnection(Connection):
         return len(buf)
 
     def do_write(self, stream_id: int, data: bytes) -> None:
-        self.connection.send_data(stream_id=stream_id, data=data, end_stream=self.closed)
+        # process any pending substream allocations (we're on the asyncio loop now)
+        if self._pending_substreams:
+            pending = list(self._pending_substreams)
+            self._pending_substreams.clear()
+            log(f"allocating pending substreams: {pending}")
+            for stream_type in pending:
+                self._allocate_substream(stream_type)
+        if stream_id in self._substream_ids:
+            # raw QUIC stream — strip WS frame header, bypass H3
+            # WS framing is always added by make_wsframe_header (format thread)
+            # and stripped here (asyncio thread) to avoid a race between the
+            # framing decision and stream routing across threads
+            data = self._strip_ws_header(data)
+            log(f"substream {stream_id}: writing {len(data)} bytes")
+            self.connection._quic.send_stream_data(stream_id=stream_id, data=data, end_stream=self.closed)
+        else:
+            # main WebSocket stream — use H3 DATA frames
+            self.connection.send_data(stream_id=stream_id, data=data, end_stream=self.closed)
 
     def get_packet_stream_id(self, packet_type: str) -> int:
+        if self.closed or not self._use_substreams or not packet_type:
+            return self.stream_id
+        if not any(packet_type.startswith(x) for x in self._substream_packet_types):
+            return self.stream_id
+        # ie: "sound-data" -> "sound", "key-action" -> "key"
+        stream_type = packet_type.split("-", 1)[0]
+        stream_id = self._packet_type_streams.get(stream_type)
+        if stream_id is not None:
+            # already allocated substream:
+            return stream_id
+        # reserve the stream type so we don't retry on the next packet;
+        # actual allocation happens on the asyncio loop in _allocate_substream()
+        self._packet_type_streams[stream_type] = self.stream_id
+        self._pending_substreams.add(stream_type)
         return self.stream_id
+
+    def _allocate_substream(self, stream_type: str) -> None:
+        """Allocate a raw QUIC stream for a packet type. Must run on the asyncio loop."""
+        log(f"_allocate_substream({stream_type!r})")
+        quic = self.connection._quic
+        try:
+            stream_id = quic.get_next_available_stream_id()
+        except Exception:
+            log(f"unable to allocate new stream-id for {stream_type!r}", exc_info=True)
+            log.warn(f"Warning: unable to allocate a new stream-id for {stream_type!r}")
+            self._use_substreams = False
+            return
+        # send type prefix as first bytes (QUIC guarantees in-order per-stream)
+        header = f"xpra:{stream_type}\n".encode()
+        log(f"sending substream header on stream {stream_id}: {header!r}")
+        quic.send_stream_data(stream_id, header)
+        self._substream_ids.add(stream_id)
+        self._packet_type_streams[stream_type] = stream_id
+        log.info(f"new substream {stream_id} for {stream_type!r}")
+        if self._register_substream:
+            self._register_substream(stream_id, self)
+
+    @staticmethod
+    def _strip_ws_header(data: bytes) -> bytes:
+        """Strip the WebSocket binary frame header from data."""
+        if len(data) < 2 or data[0] != 0x82:
+            return data
+        length_byte = data[1] & 0x7F
+        if length_byte <= 125:
+            return data[2:]
+        if length_byte == 126:
+            return data[4:]
+        # length_byte == 127
+        return data[10:]
 
     def read(self, n: int) -> bytes:
         log("quic.read(%s)", n)

--- a/xpra/net/quic/connection.py
+++ b/xpra/net/quic/connection.py
@@ -12,6 +12,7 @@ from collections.abc import Callable
 from aioquic import __version__ as aioquic_version
 from aioquic.h0.connection import H0Connection
 from aioquic.h3.connection import H3Connection
+from aioquic.h3.connection import StreamType
 from aioquic.h3.events import DataReceived, DatagramReceived, H3Event
 from aioquic.quic.packet import QuicErrorCode
 
@@ -31,6 +32,12 @@ DATAGRAM_PACKET_TYPES = tuple(x.strip() for x in os.environ.get(
     "XPRA_QUIC_DATAGRAM_PACKET_TYPES",
     ""
 ).split(",") if x.strip())
+
+# aioquic iterates _streams in dict insertion order with no priority
+# mechanism — the first stream gets full access to the congestion window.
+# This defines the send priority: types listed first get scheduled first.
+# Types not listed here (and the main WebSocket stream) are sent last.
+STREAM_PRIORITY = ("key", "pointer", "sound", "webcam", "draw")
 
 if envbool("XPRA_QUIC_LOGGER", True):
     override_aioquic_logger()
@@ -225,6 +232,80 @@ class XpraQuicConnection(Connection):
         log.info(f"new substream {stream_id} for {stream_type!r}")
         if self._register_substream:
             self._register_substream(stream_id, self)
+        try:
+            self._prioritize_streams()
+        except Exception:
+            log.warn("Warning: failed to prioritize QUIC streams", exc_info=True)
+
+    def _prioritize_streams(self) -> None:
+        """Reorder aioquic's internal stream dict so realtime streams are sent first.
+
+        aioquic's _write_application iterates _streams in dict insertion order
+        and gives each stream access to the congestion window in that order.
+        The first stream can consume the entire window, starving later ones.
+
+        Order after reordering:
+          1. Main/control streams (non-substream) — always first
+          2. Substreams in STREAM_PRIORITY order (input, audio, video)
+        """
+        quic = getattr(self.connection, "_quic", None)
+        if not quic:
+            return
+        streams = quic._streams
+        if not streams:
+            return
+
+        # map substream stream_ids to their priority index
+        type_priority = {}
+        for stream_type, sid in self._packet_type_streams.items():
+            if sid in self._substream_ids:
+                try:
+                    type_priority[sid] = STREAM_PRIORITY.index(stream_type)
+                except ValueError:
+                    type_priority[sid] = len(STREAM_PRIORITY)
+
+        # sort: non-substream entries first (main WebSocket stream, H3 control)
+        # so control packets always have priority, then substreams by STREAM_PRIORITY
+        def sort_key(item):
+            sid = item[0]
+            if sid not in type_priority:
+                return -1   # main/control streams first
+            return type_priority[sid]
+
+        sorted_items = sorted(streams.items(), key=sort_key)
+        streams.clear()
+        streams.update(sorted_items)
+        # log the reordered stream IDs with their type names for debugging
+        sid_to_type = {v: k for k, v in self._packet_type_streams.items() if v in self._substream_ids}
+        h3 = self.connection
+        # discover H3's named stream ID attributes (e.g. _local_control_stream_id)
+        h3_labels = {}
+        try:
+            for attr in dir(h3):
+                if attr.endswith("_stream_id") and attr.startswith("_"):
+                    val = getattr(h3, attr, None)
+                    if isinstance(val, int):
+                        # "_local_control_stream_id" -> "local-control"
+                        h3_labels[val] = attr[1:].removesuffix("_stream_id").replace("_", "-")
+        except Exception:
+            pass
+        h3_streams = getattr(h3, "_stream", {})
+        def label(sid):
+            if sid in sid_to_type:
+                return sid_to_type[sid]
+            if sid == self.stream_id:
+                return "websocket"
+            if sid in h3_labels:
+                return h3_labels[sid]
+            h3s = h3_streams.get(sid)
+            if h3s and h3s.stream_type is not None:
+                try:
+                    return StreamType(h3s.stream_type).name.lower()
+                except ValueError:
+                    return f"h3-{h3s.stream_type}"
+            return f"quic-{sid}"
+        order = [(sid, label(sid)) for sid, _ in sorted_items]
+        log.info("QUIC stream send priority: %s", order)
 
     @staticmethod
     def _strip_ws_header(data: bytes) -> bytes:

--- a/xpra/net/quic/connection.py
+++ b/xpra/net/quic/connection.py
@@ -5,7 +5,7 @@
 # later version. See the file COPYING for details.
 
 import os
-from queue import SimpleQueue
+from queue import Empty, SimpleQueue
 from typing import Union, Any
 from collections.abc import Callable
 
@@ -46,6 +46,7 @@ class XpraQuicConnection(Connection):
         self.socktype_wrapped = "quic"
         self.connection: HttpConnection = connection
         self.read_queue: SimpleQueue[bytes] = SimpleQueue()
+        self._raw_read_cb: Callable[[bytes, int], None] | None = None
         self.stream_id: int = stream_id
         self.transmit: Callable[[], None] = transmit
         self.accepted: bool = False
@@ -93,6 +94,20 @@ class XpraQuicConnection(Connection):
         else:
             log.warn(f"Warning: unhandled websocket http event {event}")
 
+    def _close_dead_connection(self, reason: str = "write failed") -> None:
+        """Mark connection closed and unblock the read thread.
+
+        Called when a write to the QUIC stream fails, indicating the peer
+        is gone (e.g., SIGKILL). Putting empty bytes in the read queue
+        unblocks SocketProtocol's read thread, which triggers the full
+        xpra disconnect chain (stops audio sources, cleans up state).
+        """
+        if self.closed:
+            return
+        log.info("QUIC connection dead (%s): %s", reason, self)
+        self.closed = True
+        self.read_queue.put(b"")
+
     def close(self, code=QuicErrorCode.NO_ERROR, reason="closing") -> None:
         log(f"quic.close({code}, {reason})")
         if not self.closed:
@@ -134,7 +149,7 @@ class XpraQuicConnection(Connection):
             log(f"sending {packet_type!r} using datagram")
             return len(buf)
         stream_id = self.get_packet_stream_id(packet_type)
-        log("quic.stream_write(%s, %s) using stream id %s", Ellipsizer(buf), packet_type, stream_id)
+        log("%s.stream_write(%s, %s) using stream id %s", self, Ellipsizer(buf), packet_type, stream_id)
 
         def do_write() -> None:
             if self.closed:
@@ -143,11 +158,12 @@ class XpraQuicConnection(Connection):
             try:
                 self.do_write(stream_id, data)
                 self.transmit()
-            except AssertionError:
+            except Exception:
                 if self.closed:
                     log(f"connection is already closed, packet {packet_type} dropped")
                     return
-                raise
+                log(f"write failed for {packet_type} on stream {stream_id}", exc_info=True)
+                self._close_dead_connection(f"write failed: {packet_type}")
 
         get_threaded_loop().call(do_write)
         return len(buf)
@@ -223,6 +239,26 @@ class XpraQuicConnection(Connection):
         # length_byte == 127
         return data[10:]
 
+    def put_raw_substream_data(self, data: bytes, stream_id: int = 1) -> None:
+        """Deliver substream data directly to the xpra packet parser, bypassing WebSocket framing."""
+        log(f"put_raw_substream_data: {len(data)} bytes on stream {stream_id}")
+        if self._raw_read_cb:
+            self._raw_read_cb(data, stream_id)
+        else:
+            log.warn("Warning: raw substream data received but no parser callback set")
+
+    # check for closed connection every READ_TIMEOUT seconds
+    READ_TIMEOUT = 60
+
     def read(self, n: int) -> bytes:
         log("quic.read(%s)", n)
-        return self.read_queue.get()
+        while not self.closed:
+            try:
+                return self.read_queue.get(timeout=self.READ_TIMEOUT)
+            except Empty:
+                continue
+        # drain any remaining data before signaling EOF
+        try:
+            return self.read_queue.get_nowait()
+        except Empty:
+            return b""

--- a/xpra/net/quic/listener.py
+++ b/xpra/net/quic/listener.py
@@ -1,5 +1,6 @@
 # This file is part of Xpra.
 # Copyright (C) 2022 Antoine Martin <antoine@xpra.org>
+# Copyright (C) 2026 Netflix, Inc.
 # Xpra is released under the terms of the GNU GPL v2, or, at your option, any
 # later version. See the file COPYING for details.
 
@@ -18,7 +19,7 @@ from aioquic.h3.events import (
     HeadersReceived,
     WebTransportStreamDataReceived,
 )
-from aioquic.quic.events import DatagramFrameReceived, ProtocolNegotiated, QuicEvent
+from aioquic.quic.events import ConnectionTerminated, DatagramFrameReceived, ProtocolNegotiated, QuicEvent, StreamDataReceived
 
 from xpra.net.quic.common import MAX_DATAGRAM_FRAME_SIZE
 from xpra.net.quic.http import HttpRequestHandler
@@ -35,7 +36,8 @@ from xpra.log import Logger
 
 log = Logger("quic")
 
-quic_logger = QuicLogger()
+# qlog records every QUIC frame into memory — significant GC pressure at high throughput
+quic_logger = QuicLogger() if log.is_debug_enabled() else None
 
 HttpConnection = Union[H0Connection, H3Connection]
 Handler = Union[HttpRequestHandler, ServerWebSocketConnection, ServerWebTransportConnection]
@@ -47,10 +49,45 @@ class HttpServerProtocol(QuicConnectionProtocol):
         log(f"HttpServerProtocol({args}, {kwargs}) xpra-server={self._xpra_server}")
         super().__init__(*args, **kwargs)
         self._handlers: dict[int, Handler] = {}
+        self._substream_handlers: dict[int, Handler] = {}
         self._http: HttpConnection | None = None
+
+    def register_substream(self, stream_id: int, handler: Handler) -> None:
+        log(f"register_substream({stream_id}, {handler})")
+        self._substream_handlers[stream_id] = handler
+
+    def _cleanup_handlers(self, reason: str = "") -> None:
+        """Close all handlers and unblock their read threads.
+
+        Ensures the xpra protocol detects the disconnect and cleans up
+        audio sources, client state, etc.
+        """
+        if not self._handlers:
+            return
+        log.info("cleaning up %d QUIC handlers: %s", len(self._handlers), reason)
+        for handler in self._handlers.values():
+            log.info("closing handler %s", handler)
+            try:
+                if not getattr(handler, "closed", True):
+                    handler.close()
+                # unblock the SocketProtocol read thread so it detects EOF
+                rq = getattr(handler, "read_queue", None)
+                if rq:
+                    rq.put(b"")
+            except Exception:
+                log("error closing handler %s", handler, exc_info=True)
+        self._handlers.clear()
+        self._substream_handlers.clear()
+
+    def connection_lost(self, exc) -> None:
+        self._cleanup_handlers(f"transport lost: {exc}")
+        super().connection_lost(exc)
 
     def quic_event_received(self, event: QuicEvent) -> None:
         log("hsp:quic_event_received(%s)", Ellipsizer(event))
+        if isinstance(event, ConnectionTerminated):
+            self._cleanup_handlers(f"QUIC terminated: {event.reason_phrase}")
+            return
         if isinstance(event, ProtocolNegotiated):
             if event.alpn_protocol in H3_ALPN:
                 self._http = H3Connection(self._quic, enable_webtransport=True)
@@ -58,7 +95,12 @@ class HttpServerProtocol(QuicConnectionProtocol):
                 self._http = H0Connection(self._quic)
         elif isinstance(event, DatagramFrameReceived) and event.data == b"quack":
             self._quic.send_datagram_frame(b"quack-ack")
-        #  pass event to the HTTP layer
+        # route raw QUIC substreams directly, bypassing H3
+        if isinstance(event, StreamDataReceived) and event.stream_id in self._substream_handlers:
+            log(f"substream {event.stream_id}: received {len(event.data)} bytes")
+            self._substream_handlers[event.stream_id].put_raw_substream_data(event.data, event.stream_id)
+            return
+        # pass event to the HTTP layer
         log(f"hsp:quic_event_received(..) http={self._http}")
         if self._http is not None:
             for http_event in self._http.handle_event(event):
@@ -139,7 +181,8 @@ class HttpServerProtocol(QuicConnectionProtocol):
             }
             wsc = ServerWebSocketConnection(connection=self._http, scope=scope,
                                             stream_id=event.stream_id,
-                                            transmit=self.transmit)
+                                            transmit=self.transmit,
+                                            register_substream=self.register_substream)
             socket_options = {}
             self._xpra_server.make_protocol("quic", wsc, socket_options, protocol_class=WebSocketProtocol)
             return wsc

--- a/xpra/net/quic/listener.py
+++ b/xpra/net/quic/listener.py
@@ -19,6 +19,7 @@ from aioquic.h3.events import (
     HeadersReceived,
     WebTransportStreamDataReceived,
 )
+from aioquic.quic.connection import stream_is_client_initiated, stream_is_unidirectional
 from aioquic.quic.events import ConnectionTerminated, DatagramFrameReceived, ProtocolNegotiated, QuicEvent, StreamDataReceived
 
 from xpra.net.quic.common import MAX_DATAGRAM_FRAME_SIZE
@@ -50,6 +51,7 @@ class HttpServerProtocol(QuicConnectionProtocol):
         super().__init__(*args, **kwargs)
         self._handlers: dict[int, Handler] = {}
         self._substream_handlers: dict[int, Handler] = {}
+        self._pending_client_substreams: dict[int, bytes] = {}
         self._http: HttpConnection | None = None
 
     def register_substream(self, stream_id: int, handler: Handler) -> None:
@@ -78,6 +80,55 @@ class HttpServerProtocol(QuicConnectionProtocol):
                 log("error closing handler %s", handler, exc_info=True)
         self._handlers.clear()
         self._substream_handlers.clear()
+        self._pending_client_substreams.clear()
+
+    def _handle_client_substream_data(self, event: StreamDataReceived) -> bool:
+        """Detect and register client-initiated raw QUIC substreams.
+
+        Client-initiated bidirectional streams (stream_id % 4 == 0) that are NOT
+        the main WebSocket stream are treated as substreams. The first bytes must
+        be "xpra:<type>\\n" to identify the stream type.
+        """
+        stream_id = event.stream_id
+        # only intercept client-initiated bidirectional streams
+        if not stream_is_client_initiated(stream_id) or stream_is_unidirectional(stream_id):
+            return False
+        # stream 0 is always the main WebSocket — must reach H3
+        # (can't rely on _handlers check: first event arrives before H3 registers it)
+        if stream_id == 0:
+            return False
+        # skip streams already managed by H3
+        if stream_id in self._handlers:
+            return False
+        # accumulate until we see the "xpra:<type>\n" header
+        buf = self._pending_client_substreams.get(stream_id, b"") + event.data
+        if b"\n" not in buf:
+            log(f"client substream {stream_id}: buffering {len(buf)} bytes, waiting for header")
+            self._pending_client_substreams[stream_id] = buf
+            return True
+        header, remainder = buf.split(b"\n", 1)
+        self._pending_client_substreams.pop(stream_id, None)
+        try:
+            header_str = header.decode("ascii")
+        except (UnicodeDecodeError, ValueError):
+            log.warn(f"Warning: invalid client substream header on stream {stream_id}")
+            return False
+        if not header_str.startswith("xpra:"):
+            log.warn(f"Warning: unexpected client substream header on stream {stream_id}: {header_str!r}")
+            return False
+        stream_type = header_str[5:]
+        # find the WebSocket handler (skip HTTP request handlers)
+        handler = next((h for h in self._handlers.values()
+                        if isinstance(h, ServerWebSocketConnection)), None)
+        if not handler:
+            log.warn(f"Warning: no handler for client substream {stream_id}")
+            return True
+        self._substream_handlers[stream_id] = handler
+        log.info(f"new client substream {stream_id} for {stream_type!r} packets")
+        if remainder:
+            log(f"client substream {stream_id}: delivering {len(remainder)} bytes after header")
+            handler.put_raw_substream_data(remainder, stream_id)
+        return True
 
     def connection_lost(self, exc) -> None:
         self._cleanup_handlers(f"transport lost: {exc}")
@@ -96,10 +147,14 @@ class HttpServerProtocol(QuicConnectionProtocol):
         elif isinstance(event, DatagramFrameReceived) and event.data == b"quack":
             self._quic.send_datagram_frame(b"quack-ack")
         # route raw QUIC substreams directly, bypassing H3
-        if isinstance(event, StreamDataReceived) and event.stream_id in self._substream_handlers:
-            log(f"substream {event.stream_id}: received {len(event.data)} bytes")
-            self._substream_handlers[event.stream_id].put_raw_substream_data(event.data, event.stream_id)
-            return
+        if isinstance(event, StreamDataReceived):
+            if event.stream_id in self._substream_handlers:
+                log(f"substream {event.stream_id}: received {len(event.data)} bytes")
+                self._substream_handlers[event.stream_id].put_raw_substream_data(event.data, event.stream_id)
+                return
+            # detect new client-initiated substreams
+            if self._handle_client_substream_data(event):
+                return
         # pass event to the HTTP layer
         log(f"hsp:quic_event_received(..) http={self._http}")
         if self._http is not None:

--- a/xpra/net/quic/websocket.py
+++ b/xpra/net/quic/websocket.py
@@ -1,47 +1,41 @@
 # This file is part of Xpra.
 # Copyright (C) 2022 Antoine Martin <antoine@xpra.org>
+# Copyright (C) 2026 Netflix, Inc.
 # Xpra is released under the terms of the GNU GPL v2, or, at your option, any
 # later version. See the file COPYING for details.
 
 import os
 from typing import Any
-from collections.abc import Callable, Sequence
+from collections.abc import Callable
 
 from aioquic.h3.events import HeadersReceived, H3Event
-from aioquic.h3.exceptions import NoAvailablePushIDError
 from aioquic.quic.packet import QuicErrorCode
 
 from xpra.net.common import pretty_socket
 from xpra.net.quic.connection import XpraQuicConnection
-from xpra.net.quic.common import SERVER_NAME, http_date, binary_headers
+from xpra.net.quic.common import SERVER_NAME, http_date
 from xpra.net.websockets.header import close_packet
-from xpra.util.env import first_time
-from xpra.util.str_fn import Ellipsizer, std
+from xpra.util.str_fn import Ellipsizer
 from xpra.log import Logger
 
 log = Logger("quic")
 
-# can be used to use substreams based on packet prefix: sound,webcam,draw
+# route these packet type prefixes to independent QUIC streams
 SUBSTREAM_PACKET_TYPES = tuple(x.strip() for x in os.environ.get(
     "XPRA_QUIC_SUBSTREAM_PACKET_TYPES",
-    ""
+    "sound,draw"
 ).split(",") if x.strip())
-
-
-def filterpath(path: str) -> str:
-    return std(path, "-+=&;%@._/")
-
-
-# SUBSTREAM_PACKET_LOSS_PCT = envint("XPRA_QUIC_SUBSTREAM_PACKET_LOSS_PCT", 0)
 
 
 class ServerWebSocketConnection(XpraQuicConnection):
     def __init__(self, connection, scope: dict,
-                 stream_id: int, transmit: Callable[[], None]):
+                 stream_id: int, transmit: Callable[[], None],
+                 register_substream: Callable[[int, "ServerWebSocketConnection"], None] | None = None):
         super().__init__(connection, stream_id, transmit, "", 0, "wss", info=None, options=None)
         self.scope: dict = scope
-        self._packet_type_streams: dict[str, int] = {}
-        self._use_substreams = bool(SUBSTREAM_PACKET_TYPES)
+        # configure server-specific substream packet types
+        self._substream_packet_types = SUBSTREAM_PACKET_TYPES
+        self._register_substream = register_substream
 
     def get_info(self) -> dict[str, Any]:
         info = super().get_info()
@@ -94,54 +88,3 @@ class ServerWebSocketConnection(XpraQuicConnection):
             self.send_headers(self.stream_id, headers={":status": code})
             self.transmit()
 
-    def get_packet_stream_id(self, packet_type: str) -> int:
-        if self.closed or not self._use_substreams or not packet_type:
-            return self.stream_id
-        if not any(packet_type.startswith(x) for x in SUBSTREAM_PACKET_TYPES):
-            return self.stream_id
-        # ie: "sound-data" -> "sound"
-        stream_type = packet_type.split("-", 1)[0]
-        stream_id = self._packet_type_streams.get(stream_type)
-        if stream_id is not None:
-            # already allocated substream:
-            return stream_id
-        # allocate a new one and record it
-        # (even if it fails, so we don't retry to allocate it again and again):
-        stream_id = self.allocate_new_stream_id(stream_type) or self.stream_id
-        self._packet_type_streams[stream_type] = stream_id
-        return stream_id
-
-    def scopestr(self, key: str, default: str, values: Sequence[str] = ()) -> str:
-        value = self.scope.get(key, default)
-        if values and value not in values:
-            raise ValueError(f"invalid value for {key!r}: {value!r}")
-        return value
-
-    def allocate_new_stream_id(self, stream_type: str) -> int:
-        log(f"allocate_new_stream_id({stream_type!r})")
-        # should use more "correct" values here
-        # (we don't need those headers,
-        # but the client would drop the packet without them..)
-        headers = binary_headers({
-            ":method": self.scopestr("method", "CONNECT", ("CONNECT", "CONNECT-UDP")),
-            ":scheme": self.scopestr("scheme", "wss", ("wss", "https")),
-            ":authority": self.scope.get("transport-info", {}).get("sockname", ("localhost", ))[0],
-            ":path": filterpath(self.scopestr("path", "/")),
-        })
-        try:
-            stream_id = self.connection.send_push_promise(self.stream_id, headers)
-        except NoAvailablePushIDError:
-            log(f"unable to allocate new stream-id using {self.stream_id} and {headers}", exc_info=True)
-            if first_time("quic-no-push-id"):
-                log.warn(f"Warning: unable to allocate a new stream-id for {stream_type!r}")
-            else:
-                # more than one error, stop trying:
-                self._use_substreams = False
-            return 0
-        log.info(f"new stream: {stream_id} for {stream_type!r} with headers={headers}")
-        self.send_headers(stream_id=stream_id, headers={
-            ":status": 200,
-            "substream": self.stream_id,
-            "stream-type": stream_type,
-        })
-        return stream_id

--- a/xpra/net/socket_util.py
+++ b/xpra/net/socket_util.py
@@ -580,6 +580,13 @@ def create_udp_socket(host: str, iport: int, family: socket.AddressFamily=socket
     else:
         sockaddr = (host, iport)
     sock = socket.socket(family, socket.SOCK_DGRAM)
+    # larger buffers reduce packet drops during Python GIL pauses
+    UDP_BUFFER_SIZE = int(os.environ.get("XPRA_UDP_BUFFER_SIZE", 4 * 1024 * 1024))
+    for opt in (socket.SO_RCVBUF, socket.SO_SNDBUF):
+        try:
+            sock.setsockopt(socket.SOL_SOCKET, opt, UDP_BUFFER_SIZE)
+        except OSError:
+            pass
     try:
         sock.bind(sockaddr)
     except Exception:

--- a/xpra/net/websockets/protocol.py
+++ b/xpra/net/websockets/protocol.py
@@ -34,6 +34,9 @@ class WebSocketProtocol(SocketProtocol):
         self._process_read = self.parse_ws_frame
         self.make_chunk_header: Callable = self.make_xpra_header
         self.make_frame_header: Callable = self.make_wsframe_header
+        # wire up raw substream delivery to bypass WS framing
+        if hasattr(self._conn, "_raw_read_cb"):
+            self._conn._raw_read_cb = self.substream_read_queue_put
 
     def __repr__(self):
         return f"WebSocket({self._conn})"

--- a/xpra/server/base.py
+++ b/xpra/server/base.py
@@ -276,6 +276,11 @@ class ServerBase(ServerBaseClass):
         # use blocking sockets from now on:
         if not WIN32:
             set_socket_timeout(proto._conn, None)
+        # enable QUIC substreams if the client supports them:
+        conn = proto._conn
+        if c.boolget("quic.substreams") and hasattr(conn, "_use_substreams"):
+            conn._use_substreams = True
+            log.info("enabling QUIC substreams for this client")
 
         def drop_client(reason="unknown", *args) -> None:
             self.disconnect_client(proto, reason, *args)


### PR DESCRIPTION
## Summary

Route audio, video, and input to independent QUIC streams to prevent
head-of-line blocking, replacing the broken push-promise approach that was
disabled in May 2023 due to `NoAvailablePushIDError` (#3850).

Ported from my v6.4.x daily-driver branch where this has been running for several days as a daily driver via module overrides.

**Cellular benchmark results** (no audio pipe bypass — substreams + priority only):

| Sound network jitter | TCP | QUIC single | QUIC multi |
|---|---|---|---|
| stdev (run 1) | 80ms | 109ms | **20ms** |
| stdev (run 2) | 98ms | 157ms | **17ms** |
| max (run 1) | 817ms | 1249ms | **193ms** |
| max (run 2) | 708ms | 1906ms | **147ms** |

Single-stream QUIC is *worse* than TCP on cellular — H3's single stream has
stricter in-order delivery than TCP's kernel-level buffering. Multi-stream
eliminates this entirely: 4-5x better than TCP, 6-8x better than QUIC-single.

On WiFi/LAN with sufficient bandwidth, all modes perform equivalently since the
congestion window never fills.

- **Raw QUIC streams replace push promises** — each substream is a raw QUIC
  bidirectional stream identified by a `"xpra:<type>\n"` header prefix,
  allocated via `_quic.get_next_available_stream_id()` and `send_stream_data()`.
  Push promises were fundamentally limited by the H3 push ID pool; raw streams
  have no such limit.
- **Per-stream parse state isolation** — `ParseState` class (with `__slots__`)
  holds independent reassembly state per stream in the parse thread, preventing
  interleaving corruption when draw and sound data arrive simultaneously on
  different streams.
- **Stream priority reordering** — aioquic iterates `_streams` in dict insertion
  order with no priority mechanism. When video bandwidth spikes (e.g. window
  resize, 2→100 Mbps), the video stream consumes the entire congestion window,
  starving audio and input. `_prioritize_streams()` reorders the dict after each
  allocation: control streams first, then input (key, pointer), audio (sound),
  and bulk data (draw) last.
- **Client→server substreams** — keystrokes and pointer events bypass the main
  WebSocket write queue via dedicated QUIC streams, preventing input latency
  spikes when the queue is congested with clipboard or ack packets.
- **TLS error surfacing** — override `datagram_received()` to catch TLS/OpenSSL
  exceptions and resolve the connected waiter immediately instead of hanging
  until timeout with no error message. Both fast-open and non-fast-open paths
  use `asyncio.wait_for()` with the connect timeout.
- **certifi CA fallback** — for frozen Windows builds where the OS cert store
  isn't accessible to pyOpenSSL, falls back to `certifi.where()` and checks
  relative to the executable directory.
- **Zombie connection cleanup** — `ConnectionTerminated` event handler,
  `_close_dead_connection()` on write failure, and 60s read timeout loop ensure
  the xpra disconnect chain fires reliably when a peer dies.
- **UDP buffer sizing** — 4 MiB send/receive buffers reduce packet drops during
  Python GIL pauses.
- **HOL blocking benchmark** — `tests/scripts/test_quic_hol.py` connects as a
  real QUIC client and measures inter-arrival jitter with and without substreams
  enabled. Compares TCP, QUIC-single, and QUIC-multi in sequential or parallel
  (`--parallel`) mode.

### Why raw QUIC streams instead of H3 push promises

The existing substream stub used `send_push_promise()`, which maps to HTTP/3
server push. This has two problems: (1) the push ID space is limited and
exhausted quickly, causing `NoAvailablePushIDError` after a few streams, and
(2) push promises are semantically wrong — they're meant for speculative
resource delivery, not bidirectional data channels. Raw QUIC streams have none
of these limitations and are what the QUIC transport was designed for.

### Why WS framing is stripped in do_write() instead of conditionally skipped

The WebSocket frame header (`make_wsframe_header`) is added by the format thread,
but the stream routing decision happens on the asyncio thread. A conditional
"don't add framing for substreams" check in the format thread would race with
the stream allocation on the asyncio thread. Instead, framing is always added
(no cross-thread coordination needed), and `_strip_ws_header()` removes it in
`do_write()` for substream writes, which is already on the asyncio thread.

### Why accessing aioquic private attributes

`_prioritize_streams()` reorders `_quic._streams`, and the TLS error path reads
`_connected_waiter` and `_close_event`. aioquic provides no public API for stream
scheduling or error reporting during handshake. aioquic itself uses these
attributes the same way internally. The access is wrapped in try/except so a
future aioquic refactor degrades gracefully rather than crashing.

Configurable via environment variables:
- `XPRA_QUIC_SUBSTREAM_PACKET_TYPES` — server→client (default: `sound,draw`)
- `XPRA_QUIC_CLIENT_SUBSTREAM_PACKET_TYPES` — client→server (default: `key-,pointer`)

Addresses #3854. Partially addresses #4202 (stream priority is a first step
toward congestion-aware scheduling), #4663 (zombie cleanup and TLS error
surfacing fix silent connection drops), #3850 (TLS errors now surface
immediately instead of idle timeout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Sponsored-By: Netflix