### PR TITLE
Fix QUIC connection byte counters for session info

### DIFF
--- a/xpra/net/quic/connection.py
+++ b/xpra/net/quic/connection.py
@@ -142,6 +142,8 @@ class XpraQuicConnection(Connection):
                 raise
 
         get_threaded_loop().call(do_write)
+        self.output_bytecount += len(data)
+        self.output_writecount += 1
         return len(buf)
 
     def do_write(self, stream_id: int, data: bytes) -> None:
@@ -152,4 +154,7 @@ class XpraQuicConnection(Connection):
 
     def read(self, n: int) -> bytes:
         log("quic.read(%s)", n)
-        return self.read_queue.get()
+        data = self.read_queue.get()
+        self.input_bytecount += len(data)
+        self.input_readcount += 1
+        return data


### PR DESCRIPTION
## Summary

`XpraQuicConnection.write()` and `read()` bypass the base class `_write()` and `_read()` methods that increment `input_bytecount` and `output_bytecount`. This causes the session info bytes recv/sent graphs to show zero for QUIC connections.

6-line fix — increment the counters in `stream_write()` and `read()` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Sponsored-By: Netflix