### PR TITLE
Fix nvenc cleanup out-of-context leak and nvjpeg fallback guard

### DIFF
--- a/tests/scripts/nvenc_cleanup_repro.py
+++ b/tests/scripts/nvenc_cleanup_repro.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+# This file is part of Xpra.
+# Copyright (C) 2026 Netflix, Inc.
+# Xpra is released under the terms of the GNU GPL v2, or, at your option, any
+# later version. See the file COPYING for details.
+# ABOUTME: Synthetic reproducer for nvenc `_force_context_release` out-of-context
+# ABOUTME: cleanup bug — builds a pool of fully-inited encoders, then tears them
+# ABOUTME: down while cdc.lock is held externally so each cleanup times out.
+
+"""
+Reproducer for the nvenc cleanup bug observed 2026-04-19:
+
+    pagelocked_host_allocation in out-of-thread context could not be cleaned up
+    device_allocation in out-of-thread context could not be cleaned up
+
+Root-cause hypothesis (see audit-findings.md):
+    When `do_clean()`'s `cdc.lock.acquire(timeout=5)` times out
+    (encoder.pyx:1141), it falls through to `_force_context_release()` which
+    only decrements `context_counter` and does NOT null `self.inputBuffer`,
+    `self.cudaInputBuffer`, `self.cudaOutputBuffer`. Those pycuda allocations
+    remain live on the Encoder. When the Encoder is later GC'd, Cython drops
+    those cdef refs from whatever thread holds the last reference — typically
+    the cleanup daemon thread, which does NOT have the CUDA context pushed.
+    pycuda's `__del__` emits "X in out-of-thread context could not be cleaned
+    up" warnings; the CUDA resource leaks. Enough pagelocked-memory leaks
+    exhaust the kernel's pinned-memory pool and eventually SEGV in pycuda.
+
+Design:
+    1. Build a pool of `pool_size` fully-initialized Encoder objects while
+       no contention exists. Each encoder allocates inputBuffer +
+       cudaOutputBuffer on the GPU.
+    2. Main thread enters `with cdc:` — pushes cdc.context AND acquires
+       cdc.lock. Matches the production scenario where encode_thread is
+       inside compress_image when cleanup fires.
+    3. A cleanup thread calls `.clean()` on each encoder in the pool;
+       each call invokes `do_clean` whose `cdc.lock.acquire(timeout=5)`
+       times out since main holds the lock. Force-release fires; buffers
+       are NOT nulled in any code path.
+    4. Cleanup thread drops all pool references. Cython releases
+       inputBuffer / cudaOutputBuffer from the cleanup thread, which
+       has NO context pushed. Meanwhile main has cdc.context PUSHED.
+       pycuda's __del__ can't activate the context from cleanup thread
+       (it's current in main thread) → emits the out-of-thread warning.
+    5. Main thread exits `with cdc:` once cleanup signals done.
+    6. Parent process counts "out-of-thread" warnings captured via
+       subprocess stderr. Non-zero count = bug fires, 0 count = fix works.
+
+Usage:
+    /usr/bin/python3 tests/scripts/nvenc_cleanup_repro.py
+    /usr/bin/python3 tests/scripts/nvenc_cleanup_repro.py --pool-size=8 --cycles=3
+"""
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import threading
+import time
+from typing import Optional
+
+WARNING_PATTERN = re.compile(
+    r"(pagelocked_host_allocation|device_allocation|host_allocation|module|array|stream|event)"
+    r" in out-of-thread context could not be cleaned up"
+)
+
+CLEANUP_TIMEOUT = 5.0  # matches encoder.pyx:1141 `cdc.lock.acquire(timeout=5)`
+
+
+# --------------------------- WORKER (subprocess) ---------------------------
+
+def worker_main(args: argparse.Namespace) -> int:
+    """Runs inside the subprocess. Drives the actual repro."""
+    # pycuda emits the out-of-thread-context message via PyErr_WarnEx, which
+    # goes through Python's warnings module. Default filter dedupes same
+    # (file:line, message), masking the leak count.
+    import warnings
+    warnings.simplefilter("always")
+
+    from xpra.codecs.nvidia.cuda.context import (
+        init_all_devices, load_device, cuda_device_context,
+    )
+    from xpra.codecs.nvidia.nvenc import encoder as nvenc_encoder
+    from xpra.codecs.image import ImageWrapper
+    from xpra.util.objects import typedict
+
+    nvenc_encoder.init_module({})
+    devices = init_all_devices()
+    if not devices:
+        print("FAIL: no CUDA devices", file=sys.stderr)
+        return 2
+    device_id = devices[0]
+    device = load_device(device_id)
+    cdc = cuda_device_context(device_id, device)
+    # Prime cdc: create + push/pop once so subsequent operations are warm.
+    with cdc:
+        pass
+
+    # 256x256 BGRX is reliably accepted by NVENC on A2000. The incident was
+    # at 1489x909 HEVC 4:4:4 BGRX-native; the cleanup bug is dimension-
+    # agnostic, so smaller frames keep per-encoder GPU memory under 1 MiB.
+    W = H = 256
+    pixels = bytes(W * H * 4)
+
+    def make_image() -> ImageWrapper:
+        return ImageWrapper(
+            0, 0, W, H, pixels, "BGRX", 32, W * 4,
+            planes=ImageWrapper.PACKED, thread_safe=True,
+        )
+
+    def build_encoder() -> Optional[object]:
+        enc = nvenc_encoder.Encoder()
+        try:
+            options = typedict({
+                "cuda-device-context": cdc,
+                "dst-formats": ("YUV420P", "YUV444P"),
+                "quality": 50, "speed": 50,
+                "threaded-init": False,
+            })
+            enc.init_context("h264", W, H, "BGRX", options)
+            enc.compress_image(make_image(), typedict({"cuda-device-context": cdc}))
+            return enc
+        except Exception as e:
+            print(f"[build] failed: {e!r}", file=sys.stderr)
+            try:
+                enc.clean()
+            except Exception:
+                pass
+            return None
+
+    total_created = 0
+    total_force_released = 0
+    for cycle in range(args.cycles):
+        print(f"[cycle {cycle + 1}/{args.cycles}] building pool of {args.pool_size}",
+              file=sys.stderr)
+        pool: list = []
+        while len(pool) < args.pool_size:
+            built = build_encoder()
+            if built is None:
+                break
+            pool.append(built)
+            total_created += 1
+            # Don't leave `built` bound to the last encoder — if we do, that
+            # encoder retains an extra ref past the `with cdc:` exit and its
+            # __dealloc__ then fires with no pushed context elsewhere, losing
+            # the warning signal we're trying to observe.
+            del built
+        if len(pool) < args.pool_size:
+            # Partial pool means the reproducer couldn't set up the scenario
+            # as requested (usually resource exhaustion or NVENC init error).
+            # This is infrastructure failure, not a valid fix-verification
+            # run, so signal it distinctly.
+            print(f"[cycle] FAIL: built only {len(pool)}/{args.pool_size} encoders",
+                  file=sys.stderr)
+            # Drop whatever we did build before returning.
+            for e in pool:
+                try:
+                    e.clean()
+                except Exception:
+                    pass
+            pool.clear()
+            sys.stderr.flush()
+            os._exit(4)
+
+        # Cleanup thread: clean + drop pool refs.
+        # Each clean() -> do_clean() waits CLEANUP_TIMEOUT seconds for the
+        # lock, times out, falls into _force_context_release().
+        # Then the cleanup thread drops all pool refs, triggering Cython
+        # __dealloc__ on THIS thread, releasing inputBuffer/cudaOutputBuffer
+        # from pycuda. Main thread holds cdc.context pushed in `with cdc:`
+        # below, so pycuda sees the context as out-of-thread and warns.
+        cleanup_done = threading.Event()
+        import gc
+
+        def cleanup_worker(local_pool: list) -> None:
+            nonlocal total_force_released
+            # Pop-and-clean so no loop variable ends up holding the last
+            # encoder's ref past the `del local_pool[:]`. If we used
+            # `for e in local_pool`, `e` would retain the last element
+            # until function exit — past cleanup_done.set() — so main
+            # would exit `with cdc:` before that __dealloc__ fires,
+            # turning one encoder (all of them at pool_size=1) into a
+            # false negative.
+            while local_pool:
+                enc = local_pool.pop(0)
+                try:
+                    enc.clean()
+                    total_force_released += 1
+                except Exception as ex:
+                    print(f"[cleanup] clean() raised: {ex!r}", file=sys.stderr)
+                del enc  # drop this encoder's ref immediately
+            gc.collect()
+            cleanup_done.set()
+
+        # Transfer pool ownership to a local the cleanup thread will clear.
+        cleanup_pool = list(pool)
+        pool.clear()
+
+        t = threading.Thread(
+            target=cleanup_worker, args=(cleanup_pool,),
+            name="cleanup", daemon=True,
+        )
+
+        print(f"[cycle] entering `with cdc:` — push context + hold lock",
+              file=sys.stderr)
+        with cdc:
+            t.start()
+            # Wait inside the with-block so cdc.context stays pushed here
+            # AND cdc.lock stays held, while cleanup thread times out.
+            hold = CLEANUP_TIMEOUT * args.pool_size + 3.0
+            if not cleanup_done.wait(timeout=hold):
+                print(f"[cycle] cleanup thread hasn't finished after {hold:.1f}s, "
+                      f"releasing anyway", file=sys.stderr)
+        print("[cycle] exited `with cdc:`", file=sys.stderr)
+
+        t.join(timeout=10)
+        time.sleep(0.5)
+
+    print(f"[summary] encoders_created={total_created} force_released={total_force_released}",
+          file=sys.stderr)
+    # Skip atexit / pycuda cleanup — by design we have leaked pycuda
+    # allocations (the whole point of this repro), and pycuda's own
+    # shutdown path hangs trying to reconcile them with a half-torn-down
+    # CUDA context. The parent already has what it needs via stderr.
+    sys.stderr.flush()
+    sys.stdout.flush()
+    os._exit(0)
+
+
+# --------------------------- PARENT (driver) ---------------------------
+
+def parent_main(args: argparse.Namespace) -> int:
+    """Runs the worker as a subprocess and counts warnings."""
+    env = dict(os.environ)
+    env["XPRA_NVENC_CLEANUP_REPRO_CHILD"] = "1"
+    cmd = [sys.executable, os.path.abspath(__file__),
+           f"--pool-size={args.pool_size}",
+           f"--cycles={args.cycles}"]
+    print(f"[parent] launching child: {' '.join(cmd)}")
+    proc = subprocess.Popen(
+        cmd, env=env,
+        stdout=sys.stdout, stderr=subprocess.PIPE, text=True,
+    )
+    warning_counts: dict[str, int] = {}
+    saw_summary = False
+    assert proc.stderr is not None
+    for line in proc.stderr:
+        sys.stderr.write(line)
+        sys.stderr.flush()
+        m = WARNING_PATTERN.search(line)
+        if m:
+            warning_counts[m.group(1)] = warning_counts.get(m.group(1), 0) + 1
+        if "[summary] encoders_created=" in line:
+            saw_summary = True
+    rc = proc.wait()
+
+    print()
+    print("=" * 60)
+    print(f"[parent] child exit code: {rc}")
+    # rc=4 is the partial-pool infra signal. rc!=0 catches crashes.
+    # saw_summary catches the case where the child died before finishing
+    # all cycles. Any of these = no valid scenario run.
+    if rc != 0 or not saw_summary:
+        print("[parent] INFRASTRUCTURE ERROR — child did not complete the")
+        print(f"[parent] reproducer scenario (rc={rc}, saw_summary={saw_summary}).")
+        print("[parent] This is NOT a valid fix-verification result.")
+        return 2
+    if warning_counts:
+        print("[parent] DETECTED out-of-thread context warnings:")
+        for kind, count in sorted(warning_counts.items()):
+            print(f"    {kind}: {count}")
+        print("[parent] REPRO CONFIRMED — the bug fires under this workload.")
+        return 1
+    print("[parent] no out-of-thread context warnings observed.")
+    print("[parent] REPRO NEGATIVE — the fix appears to be effective.")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--pool-size", type=int, default=4,
+                    help="encoders per cycle (each allocates ~0.5 MiB pinned + GPU)")
+    ap.add_argument("--cycles", type=int, default=2,
+                    help="number of build+contend-teardown cycles to run")
+    args = ap.parse_args()
+
+    if os.environ.get("XPRA_NVENC_CLEANUP_REPRO_CHILD"):
+        return worker_main(args)
+    return parent_main(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/xpra/codecs/nvidia/nvenc/encoder.pyx
+++ b/xpra/codecs/nvidia/nvenc/encoder.pyx
@@ -411,6 +411,7 @@ cdef class Encoder:
     cdef uint8_t closed
     cdef uint16_t datagram
     cdef uint8_t threaded_init
+    cdef object init_complete  # threading.Event, set when threaded_init_device returns
 
     cdef object file
 
@@ -534,6 +535,13 @@ cdef class Encoder:
 
         self.threaded_init = options.boolget("threaded-init", THREADED_INIT)
         if self.threaded_init:
+            # `init_complete` lets threaded_clean serialize against
+            # threaded_init_device without needing the module-global
+            # `device_lock`. Without this, a close-during-init can let
+            # cleanup interleave with init_nvenc (which runs outside
+            # cdc.lock by design), corrupting state.
+            from threading import Event
+            self.init_complete = Event()
             start_thread(self.threaded_init_device, "threaded-init-device", daemon=True, args=(options,))
         else:
             self.init_device(options)
@@ -560,26 +568,34 @@ cdef class Encoder:
 
     def threaded_init_device(self, options: typedict) -> None:
         global device_lock
-        with device_lock:
-            if SLOW_DOWN_INIT:
-                import time
-                time.sleep(SLOW_DOWN_INIT)
-            try:
-                self.init_device(options)
-            except NVENCException as e:
-                log("threaded_init_device(%s)", options, exc_info=True)
-                log.warn("Warning: failed to initialize NVENC device")
-                if not e.api_message:
-                    log.warn(" unknown error %i", e.code)
-                else:
-                    log.warn(" error %i:", e.code)
-                    log.warn(" '%s'", e.api_message)
-                self.clean()
-            except Exception as e:
-                log("threaded_init_device(%s)", options, exc_info=True)
-                log.warn("Warning: failed to initialize device:")
-                log.warn(" %s", e)
-                self.clean()
+        try:
+            with device_lock:
+                if SLOW_DOWN_INIT:
+                    import time
+                    time.sleep(SLOW_DOWN_INIT)
+                try:
+                    self.init_device(options)
+                except NVENCException as e:
+                    log("threaded_init_device(%s)", options, exc_info=True)
+                    log.warn("Warning: failed to initialize NVENC device")
+                    if not e.api_message:
+                        log.warn(" unknown error %i", e.code)
+                    else:
+                        log.warn(" error %i:", e.code)
+                        log.warn(" '%s'", e.api_message)
+                    self.clean()
+                except Exception as e:
+                    log("threaded_init_device(%s)", options, exc_info=True)
+                    log.warn("Warning: failed to initialize device:")
+                    log.warn(" %s", e)
+                    self.clean()
+        finally:
+            # Signal threaded_clean (which may already be spawned by a
+            # self.clean() call above, or by a concurrent disconnect on
+            # the calling side) that init has completed — success or
+            # failure — so it's safe to tear down encoder state.
+            if self.init_complete is not None:
+                self.init_complete.set()
 
     def init_device(self, options: typedict) -> None:
         global bad_presets
@@ -1125,35 +1141,46 @@ cdef class Encoder:
                 self.do_clean()
 
     def threaded_clean(self) -> None:
-        global device_lock
-        with device_lock:
-            self.do_clean()
+        # Wait for threaded_init_device to finish before cleaning up.
+        # init_device drops cdc.lock between init_cuda_kernel and
+        # init_nvenc (by design — the NVENC example accesses the context
+        # after pop). That leaves a window where cleanup could otherwise
+        # interleave with init_nvenc's `nvEncRegisterResource` while
+        # buffer_clean is nulling out `self.cudaOutputBuffer`.
+        # `init_complete` provides per-encoder serialization — decoupled
+        # from the global `device_lock`, which is reserved for init and
+        # so doesn't cross-block new-encoder startup behind this wait.
+        if self.init_complete is not None:
+            self.init_complete.wait()
+        self.do_clean()
 
     def do_clean(self):
         cdc = self.cuda_device_context
         log("clean() cuda_context=%s, encoder context=%#x", cdc, <uintptr_t> self.context)
         if cdc:
-            # Use blocking lock acquisition for cleanup.
-            # cuda_device_context.__enter__ uses non-blocking acquire(False)
-            # which raises TransientCodecException if the encode thread
-            # holds the lock during compress_image(). Since do_clean runs
-            # in a daemon thread, it can afford to wait.
-            if not cdc.lock.acquire(timeout=5):
-                log.warn("Warning: timeout acquiring CUDA device lock for encoder cleanup")
-                self._force_context_release()
-                self.cuda_device_context = None
-            else:
+            # Block indefinitely on cdc.lock. Earlier revisions used a 5s
+            # timeout with an `_force_context_release` fallback, but the
+            # fallback left `self.inputBuffer` / `self.cudaInputBuffer` /
+            # `self.cudaOutputBuffer` live on the Encoder; when the Encoder
+            # was subsequently GC'd from a thread without the CUDA context
+            # pushed, pycuda emitted "X in out-of-thread context could not
+            # be cleaned up" warnings and leaked the underlying pinned /
+            # device memory. Accumulated pinned-memory leaks eventually
+            # SEGV in pycuda. compress_image always finishes in bounded
+            # time and do_clean runs on a daemon thread, so waiting is
+            # safe — strictly preferable to leaking.
+            cdc.lock.acquire()
+            try:
+                if cdc.context:
+                    cdc.context.push()
                 try:
-                    if cdc.context:
-                        cdc.context.push()
-                    try:
-                        self.cuda_clean()
-                    finally:
-                        if cdc.context:
-                            cdc.context.pop()
-                    self.cuda_device_context = None
+                    self.cuda_clean()
                 finally:
-                    cdc.lock.release()
+                    if cdc.context:
+                        cdc.context.pop()
+                self.cuda_device_context = None
+            finally:
+                cdc.lock.release()
         self.width = 0
         self.height = 0
         self.input_width = 0
@@ -1170,7 +1197,8 @@ cdef class Encoder:
         self.cuda_info = None
         self.pycuda_info = None
         self.cuda_device_info = None
-        self.kernel = None
+        # self.kernel is nulled inside cuda_clean under the pushed
+        # context; doing it here would leak the underlying Module.
         self.kernel_name = ""
         self.max_block_sizes = 0
         self.max_grid_sizes = 0
@@ -1193,15 +1221,6 @@ cdef class Encoder:
         self.bytes_in = 0
         self.bytes_out = 0
         log("clean() done")
-
-    def _force_context_release(self):
-        # last-resort fallback when the CUDA device lock times out:
-        # decrement the counter so scoring is not permanently degraded
-        if self.context!=NULL:
-            log.warn("Warning: releasing nvenc context counter without proper CUDA cleanup")
-            self.context = NULL
-            global context_counter
-            context_counter.decrease()
 
     cdef void cuda_clean(self):
         log("cuda_clean()")
@@ -1237,6 +1256,12 @@ cdef class Encoder:
         else:
             log("skipping encoder context cleanup")
         self.cuda_context_ptr = <void *> 0
+        # Release the CUDA kernel Function (and its parent Module) while
+        # the context is still pushed. Doing this from do_clean after
+        # context.pop() would drop the last ref in an out-of-thread
+        # context and trigger pycuda's "module in out-of-thread context
+        # could not be cleaned up" warning + leak.
+        self.kernel = None
 
     cdef void buffer_clean(self):
         if self.inputHandle!=NULL and self.context!=NULL:

--- a/xpra/server/window/video_compress.py
+++ b/xpra/server/window/video_compress.py
@@ -441,7 +441,7 @@ class WindowVideoSource(WindowSource):
         # and the fallback should be reliable.
         # also, we only want picture encodings here,
         # and filtering using EDGE_ENCODING_ORDER gives us that.
-        if encoder_name != "nvjpeg" and encoding in EDGE_ENCODING_ORDER:
+        if encoder_name != "enc_nvjpeg" and encoding in EDGE_ENCODING_ORDER:
             self.video_fallback_encodings.setdefault(encoding, []).insert(0, encode_fn)
 
     def update_encoding_selection(self, encoding="", exclude=None, init=False) -> None:


### PR DESCRIPTION
## Summary

Two related fixes in the nvenc / fallback cleanup path, reachable under content-type-change storms on HEVC 4:4:4 nvenc (e.g. Microsoft Edge tab restore with multiple video windows):

- **nvenc `do_clean` leaks pycuda allocations → SEGV.** `cdc.lock.acquire(timeout=5)` with an `_force_context_release()` fallback left `self.inputBuffer` / `self.cudaInputBuffer` / `self.cudaOutputBuffer` live on the Encoder when the acquire timed out. Those pycuda allocations were then GC'd from the daemon cleanup thread without a CUDA context pushed, emitting `pagelocked_host_allocation in out-of-thread context could not be cleaned up` + leaking pinned memory until pycuda SEGV'd. The bug predates PR #4848 (pre-#4848, `do_clean` silently skipped cleanup on lock contention; #4848 fixed counter accounting but not the buffer leak).

  Fix: `do_clean` now uses blocking `cdc.lock.acquire()` and drops `_force_context_release` entirely. `threaded_clean` no longer takes `device_lock` — a new per-encoder `init_complete` `threading.Event` serializes cleanup against init of the *same* encoder without cross-blocking init of other encoders on a stuck compress_image. `self.kernel = None` is moved into `cuda_clean` so the Function/Module release happens under the pushed context (fixes a related "module in out-of-thread context" warning).

- **nvjpeg was never actually excluded from the video fallback list.** The guard added in b39162652f ("don't use nvjpeg as video fallback encoding") checks `encoder_name != "nvjpeg"`, but nvjpeg is registered via `add("enc_nvjpeg")` in `WindowSource.do_init_encoders` — so `encoder_name == "enc_nvjpeg"` at the check site and the guard has never matched. nvjpeg has silently been first in the fallback list for ~3 years, contrary to the commit's stated intent. One-liner: `"nvjpeg"` → `"enc_nvjpeg"`.

A synthetic reproducer is included at `tests/scripts/nvenc_cleanup_repro.py` — builds a pool of initialized Encoders, forces cleanup under cdc-lock contention, counts pycuda out-of-context warnings via subprocess capture. Before the fix: REPRO CONFIRMED. After: REPRO NEGATIVE.

Sponsored-By: Netflix