### PR TITLE
Load all content-type rules across files and dirs

### DIFF
--- a/tests/unittests/unit/server/window/content_guesser_test.py
+++ b/tests/unittests/unit/server/window/content_guesser_test.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+# This file is part of Xpra.
+# Copyright (C) 2026 Netflix, Inc.
+# Xpra is released under the terms of the GNU GPL v2, or, at your option, any
+# later version. See the file COPYING for details.
+
+import os
+import tempfile
+import unittest
+from unittest.mock import patch
+
+from xpra.os_util import POSIX
+from xpra.server.window import content_guesser
+from xpra.server.window.content_guesser import (
+    _load_dict_dirs,
+    parse_content_types,
+    parse_content_categories_file,
+    guess_content_type_from_defs,
+    _merge_defs,
+)
+
+
+class TestContentGuesser(unittest.TestCase):
+
+    def test_merge_defs_nested_preserves_both_sides(self):
+        # nested {prop: {key: value}} dicts must merge inner dicts,
+        # not replace them — otherwise rules from one file/dir wipe another.
+        target = {"class-instance": {"r1": "a", "r2": "b"}}
+        source = {"class-instance": {"r3": "c"}}
+        _merge_defs(target, source)
+        self.assertEqual(target, {"class-instance": {"r1": "a", "r2": "b", "r3": "c"}})
+
+    def test_merge_defs_inner_key_collision_source_wins(self):
+        # when both sides define the same inner key, source replaces target —
+        # this matches plain dict.update() semantics within a single tier (e.g. all files in /etc).
+        target = {"class-instance": {"r1": "system"}}
+        source = {"class-instance": {"r1": "user"}}
+        _merge_defs(target, source)
+        self.assertEqual(target, {"class-instance": {"r1": "user"}})
+
+    def test_load_dict_dirs_preserves_system_prop_name_order(self):
+        # regression: a user adding e.g. class-instance:kitty=text must not promote
+        # class-instance ahead of system's title/role properties.
+        # guess_content_type_from_defs iterates by property in dict order and stops
+        # at the first match, so a Firefox Gmail window (matched by title=Gmail) must
+        # still classify as text, not as browser via class-instance=firefox.
+        with tempfile.TemporaryDirectory() as sysdir, tempfile.TemporaryDirectory() as userdir:
+            os.makedirs(os.path.join(sysdir, "content-type"))
+            os.makedirs(os.path.join(userdir, "content-type"))
+            with open(os.path.join(sysdir, "content-type", "30_title.conf"), "w") as f:
+                f.write("title:- Gmail -=text\n")
+            with open(os.path.join(sysdir, "content-type", "50_class.conf"), "w") as f:
+                f.write("class-instance:firefox=browser\n")
+            with open(os.path.join(userdir, "content-type", "50.conf"), "w") as f:
+                f.write("class-instance:kitty=text\n")
+
+            with patch.object(content_guesser, "get_system_conf_dirs", return_value=[sysdir]), \
+                    patch.object(content_guesser, "get_user_conf_dirs", return_value=[userdir]), \
+                    patch.object(content_guesser, "POSIX", False):
+                defs = _load_dict_dirs("content-type", parse_content_types)
+
+            self.assertEqual(list(defs.keys()), ["title", "class-instance"])
+
+            class FakeWindow:
+                def get_property_names(self):
+                    return ("title", "class-instance")
+
+                def get_property(self, name):
+                    return {"title": "Inbox - Gmail - user@gmail.com", "class-instance": "firefox"}[name]
+
+            with patch.object(content_guesser, "content_type_defs", defs):
+                self.assertEqual(guess_content_type_from_defs(FakeWindow()), "text")
+
+    def test_merge_defs_flat_dict_replaces(self):
+        # flat dicts (e.g. content-categories) keep simple update semantics.
+        target = {"k1": "v1", "k2": "v2"}
+        source = {"k2": "v2'", "k3": "v3"}
+        _merge_defs(target, source)
+        self.assertEqual(target, {"k1": "v1", "k2": "v2'", "k3": "v3"})
+
+    def test_load_dict_dirs_merges_system_and_user_class_instance(self):
+        # regression: a user class-instance file must not wipe the system class-instance file.
+        with tempfile.TemporaryDirectory() as sysdir, tempfile.TemporaryDirectory() as userdir:
+            os.makedirs(os.path.join(sysdir, "content-type"))
+            os.makedirs(os.path.join(userdir, "content-type"))
+            with open(os.path.join(sysdir, "content-type", "50_class.conf"), "w") as f:
+                f.write("class-instance:xterm=text\n")
+                f.write("class-instance:jetbrains.*=text\n")
+            with open(os.path.join(userdir, "content-type", "50_extras.conf"), "w") as f:
+                f.write("class-instance:kitty=text\n")
+
+            with patch.object(content_guesser, "get_system_conf_dirs", return_value=[sysdir]), \
+                    patch.object(content_guesser, "get_user_conf_dirs", return_value=[userdir]), \
+                    patch.object(content_guesser, "POSIX", False):
+                defs = _load_dict_dirs("content-type", parse_content_types)
+
+            patterns = {regex_str for regex_str, _ in defs["class-instance"].values()}
+            self.assertIn("xterm", patterns)
+            self.assertIn("jetbrains.*", patterns)
+            self.assertIn("kitty", patterns)
+
+    def test_load_dict_dirs_later_system_dir_overrides_earlier(self):
+        # regression: later system conf dirs (e.g. /etc/xdg/xpra) must be able to
+        # override the same regex/key from earlier ones (e.g. /etc/xpra).
+        # This matches the pre-fix behavior where the system-tier loop used dict.update.
+        with tempfile.TemporaryDirectory() as sysdir1, tempfile.TemporaryDirectory() as sysdir2:
+            os.makedirs(os.path.join(sysdir1, "content-type"))
+            os.makedirs(os.path.join(sysdir2, "content-type"))
+            with open(os.path.join(sysdir1, "content-type", "50.conf"), "w") as f:
+                f.write("class-instance:foo=text\n")
+            with open(os.path.join(sysdir2, "content-type", "50.conf"), "w") as f:
+                f.write("class-instance:foo=video\n")
+
+            with patch.object(content_guesser, "get_system_conf_dirs", return_value=[sysdir1, sysdir2]), \
+                    patch.object(content_guesser, "get_user_conf_dirs", return_value=[]), \
+                    patch.object(content_guesser, "POSIX", False):
+                defs = _load_dict_dirs("content-type", parse_content_types)
+
+            content_types = {ct for _, ct in defs["class-instance"].values()}
+            self.assertEqual(content_types, {"video"})
+
+    def test_load_dict_dirs_merges_two_system_files_with_same_prop(self):
+        # regression: 90_fallback.conf's role rule must not wipe 10_role.conf's role rules.
+        with tempfile.TemporaryDirectory() as sysdir:
+            os.makedirs(os.path.join(sysdir, "content-type"))
+            with open(os.path.join(sysdir, "content-type", "10_role.conf"), "w") as f:
+                f.write("role:gimp-dock=text\n")
+                f.write("role:gimp-toolbox=text\n")
+            with open(os.path.join(sysdir, "content-type", "90_fallback.conf"), "w") as f:
+                f.write("role:browser=browser\n")
+
+            with patch.object(content_guesser, "get_system_conf_dirs", return_value=[sysdir]), \
+                    patch.object(content_guesser, "get_user_conf_dirs", return_value=[]), \
+                    patch.object(content_guesser, "POSIX", False):
+                defs = _load_dict_dirs("content-type", parse_content_types)
+
+            patterns = {regex_str for regex_str, _ in defs["role"].values()}
+            self.assertEqual(patterns, {"gimp-dock", "gimp-toolbox", "browser"})
+
+    @unittest.skipUnless(POSIX, "do_get_user_conf_dirs only returns literal '~' paths on POSIX")
+    def test_load_dict_dirs_expands_tilde_in_user_dirs(self):
+        # regression: do_get_user_conf_dirs returns paths with literal '~' (so multi-user
+        # callers can osexpand against the target user). _load_dict_dir must expand '~'
+        # against $HOME for the same-user case, otherwise os.path.exists silently rejects it.
+        with tempfile.TemporaryDirectory() as homedir:
+            os.makedirs(os.path.join(homedir, ".config", "xpra", "content-type"))
+            with open(os.path.join(homedir, ".config", "xpra", "content-type", "50.conf"), "w") as f:
+                f.write("class-instance:kitty=text\n")
+
+            # patch getuid so the user-dirs branch is taken even when tests run as root
+            with patch.dict(os.environ, {"HOME": homedir}, clear=False), \
+                    patch.object(content_guesser, "get_system_conf_dirs", return_value=[]), \
+                    patch.object(content_guesser, "get_user_conf_dirs", return_value=["~/.config/xpra"]), \
+                    patch.object(content_guesser, "getuid", return_value=1000):
+                defs = _load_dict_dirs("content-type", parse_content_types)
+
+            patterns = {regex_str for regex_str, _ in defs["class-instance"].values()}
+            self.assertEqual(patterns, {"kitty"})
+
+    def test_load_dict_dirs_user_rule_overrides_broad_system_regex(self):
+        # regression: a user override must take precedence over a broader system regex
+        # earlier in iteration order. guess_content_type_from_defs stops on the first
+        # match, so user rules must iterate before system rules.
+        with tempfile.TemporaryDirectory() as sysdir, tempfile.TemporaryDirectory() as userdir:
+            os.makedirs(os.path.join(sysdir, "content-type"))
+            os.makedirs(os.path.join(userdir, "content-type"))
+            with open(os.path.join(sysdir, "content-type", "50.conf"), "w") as f:
+                # broad pattern first, specific second — file order matters
+                f.write("class-instance:.*terminal.*=text\n")
+                f.write("class-instance:gnome-terminal.*=text\n")
+            with open(os.path.join(userdir, "content-type", "50.conf"), "w") as f:
+                # user wants gnome-terminal classified as video
+                f.write("class-instance:gnome-terminal.*=video\n")
+
+            with patch.object(content_guesser, "get_system_conf_dirs", return_value=[sysdir]), \
+                    patch.object(content_guesser, "get_user_conf_dirs", return_value=[userdir]), \
+                    patch.object(content_guesser, "POSIX", False):
+                defs = _load_dict_dirs("content-type", parse_content_types)
+
+            class FakeWindow:
+                def get_property_names(self):
+                    return ("class-instance",)
+
+                def get_property(self, name):
+                    return "gnome-terminal-server"
+
+            with patch.object(content_guesser, "content_type_defs", defs):
+                ctype = guess_content_type_from_defs(FakeWindow())
+            self.assertEqual(ctype, "video")
+
+    def test_load_dict_dirs_flat_parser_unaffected(self):
+        # content-categories parser produces a flat {category: type} dict; merge must still work.
+        with tempfile.TemporaryDirectory() as sysdir, tempfile.TemporaryDirectory() as userdir:
+            os.makedirs(os.path.join(sysdir, "content-categories"))
+            os.makedirs(os.path.join(userdir, "content-categories"))
+            with open(os.path.join(sysdir, "content-categories", "50.conf"), "w") as f:
+                f.write("audio:audio\n")
+                f.write("video:video\n")
+            with open(os.path.join(userdir, "content-categories", "50.conf"), "w") as f:
+                f.write("video:audio+video\n")
+                f.write("game:video\n")
+
+            with patch.object(content_guesser, "get_system_conf_dirs", return_value=[sysdir]), \
+                    patch.object(content_guesser, "get_user_conf_dirs", return_value=[userdir]), \
+                    patch.object(content_guesser, "POSIX", False):
+                defs = _load_dict_dirs("content-categories", parse_content_categories_file)
+
+            self.assertEqual(defs, {"audio": "audio", "video": "audio+video", "game": "video"})
+
+
+def main():
+    unittest.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/xpra/server/window/content_guesser.py
+++ b/xpra/server/window/content_guesser.py
@@ -51,18 +51,37 @@ def _load_dict_file(filename: str, parser: ConfParser) -> ConfDict:
     return parser(lines)
 
 
+def _merge_defs(target: ConfDict, source: ConfDict) -> None:
+    # merge source into target, recursing one level for nested dicts.
+    # parsers like parse_content_types return {prop_name: {regex: ...}};
+    # a plain dict.update() at the top level would discard target[prop_name]
+    # whenever source defines the same prop_name in another file or dir
+    # (e.g. 90_fallback.conf's role rule wiping all role rules from 10_role.conf).
+    for k, v in source.items():
+        existing = target.get(k)
+        if isinstance(v, dict) and isinstance(existing, dict):
+            existing.update(v)
+        else:
+            target[k] = v
+
+
 def _load_dict_dir(d: str, parser: ConfParser) -> ConfDict:
-    # load all the .conf files from the directory
+    # load all the .conf files from the directory.
+    # do_get_user_conf_dirs returns paths with literal '~' so they can be expanded
+    # against the target user when osexpand is called (e.g. xpra/scripts/config.py
+    # for multi-user proxies). This loader is server-side, called as the user the
+    # rules belong to, so a plain expanduser is the right resolution here.
+    d = os.path.expanduser(d)
     if not os.path.exists(d) or not os.path.isdir(d):
         log("load_content_categories_dir(%s) directory not found", d)
         return {}
-    v = {}
+    v: ConfDict = {}
     for f in sorted(os.listdir(d)):
         if f.endswith(".conf"):
             cc_file = os.path.join(d, f)
             if os.path.isfile(cc_file):
                 try:
-                    v.update(_load_dict_file(cc_file, parser))
+                    _merge_defs(v, _load_dict_file(cc_file, parser))
                 except Exception as e:
                     log("_load_dict_dir(%s)", cc_file, exc_info=True)
                     log.error("Error loading file data from '%s'", cc_file)
@@ -76,15 +95,36 @@ def _load_dict_dirs(dirname: str, parser: ConfParser) -> ConfDict:
         return {}
     # finds all the ".conf" files from the dirname specified
     # and calls `load` on them.
-    # looks for system and user conf dirs
-    values = {}
+    # build system and user tiers separately so we can combine them with the
+    # right precedence semantics for guess_content_type_from_defs, which iterates
+    # by property in dict order and stops at the first regex match.
+    system: ConfDict = {}
     for d in get_system_conf_dirs():
-        v = _load_dict_dir(os.path.join(d, dirname), parser)
-        values.update(v)
+        _merge_defs(system, _load_dict_dir(os.path.join(d, dirname), parser))
+    user: ConfDict = {}
     if not POSIX or getuid() > 0:
         for d in get_user_conf_dirs():
-            v = _load_dict_dir(os.path.join(d, dirname), parser)
-            values.update(v)
+            _merge_defs(user, _load_dict_dir(os.path.join(d, dirname), parser))
+    # combine: keep system's prop_name iteration order (so unrelated system rules
+    # like title/role aren't pushed behind class-instance just because the user
+    # added a class-instance rule); within each property, user regexes iterate
+    # before system regexes so a user override beats a broader system regex like
+    # '.*terminal.*'. User-only properties are appended at the end.
+    values: ConfDict = {}
+    for prop_name, sys_v in system.items():
+        user_v = user.get(prop_name)
+        if isinstance(sys_v, dict) and isinstance(user_v, dict):
+            inner = dict(user_v)
+            for ik, iv in sys_v.items():
+                inner.setdefault(ik, iv)
+            values[prop_name] = inner
+        elif user_v is not None:
+            values[prop_name] = user_v
+        else:
+            values[prop_name] = sys_v
+    for prop_name, user_v in user.items():
+        if prop_name not in values:
+            values[prop_name] = user_v
     return values
 
 


### PR DESCRIPTION
## Summary

Two related issues in `xpra/server/window/content_guesser.py` cause user
and fallback rules to be silently dropped when loading
`content-type` / `content-categories` / `content-parent` defs.

### 1. Tilde paths from `do_get_user_conf_dirs` never load

`_load_dict_dir` calls `os.path.exists()` to skip missing directories.
On POSIX, `do_get_user_conf_dirs()` returns paths with literal `~`
(e.g. `"~/.config/xpra"`), and `os.path.exists("~/...")` returns
False without expansion — silent failure. **Any rules under
`~/.config/xpra/...` or `~/.xpra/...` are never loaded.**

The literal `~` in `do_get_user_conf_dirs` is intentional so multi-user
callers like `get_xpra_defaults_dirs(username, uid, gid)` in
`xpra/scripts/config.py` can pass these paths through
`osexpand(actual_username=..., uid=..., gid=...)` and resolve them
against the **target** user's home (proxy/start-as flows running as
root). Expanding `~` inside `do_get_user_conf_dirs` would bind the path
to the current process's HOME and break those flows. Expand at the
point of use in the loader instead, where the server is running as the
user the rules belong to.

### 2. Shallow `dict.update()` discards rules across files and dirs

`parse_content_types` returns a 2-level `{prop_name: {regex: tuple}}`
dict, but `_load_dict_dir` and `_load_dict_dirs` combine results with
`dict.update()`, which replaces the entire inner dict for any
`prop_name` defined in both source and target.

Symptoms:

- `90_fallback.conf`'s `role:browser=browser` replaces all role rules
  from `10_role.conf` (`gimp-dock`, `vlc-playlist`, etc).
- Once issue 1 is fixed and a user's
  `~/.config/xpra/content-type/50_extras.conf` actually loads with
  e.g. `class-instance:kitty=text`, the user's `class-instance` map
  replaces `/etc/xpra/content-type/50_class.conf`'s `class-instance`
  map wholesale — `xterm`, `jetbrains.*`, `gnome-terminal`, etc.
  lose their `text` classification and fall through to video encoding,
  which hurts text rendering quality and latency.

Fix:

- A small `_merge_defs` helper recurses one level when both sides are
  dicts. Behavior is unchanged for parsers that return flat dicts
  (`content-categories`, `content-parent`).
- `_load_dict_dirs` builds system and user tiers separately, then
  combines them so that:
  1. System's `prop_name` iteration order is preserved
     (`role`, `title`, `class-instance`, ...). `guess_content_type_from_defs`
     iterates by property and stops at the first match, so a user
     adding e.g. `class-instance:kitty=text` should not promote the
     class-instance property ahead of system's title rules — that
     would change classifications for unrelated windows like a
     Firefox Gmail tab matched by `title:- Gmail -=text`.
  2. Within each property, user regexes iterate before system regexes
     so a user override beats a broader system regex like
     `class-instance:.*terminal.*=text`.

Tests cover both regressions, the tilde expansion, the user-override
scenario (full `guess_content_type_from_defs` end-to-end), the
prop_name-order preservation, multi-system-dir precedence, and the
flat-parser regression.

Sponsored-By: Netflix