### PR TITLE
image-filter: support external 'py:' transforms and forward scroll hints

### DIFF
--- a/xpra/codecs/pytorch/filter.py
+++ b/xpra/codecs/pytorch/filter.py
@@ -3,6 +3,8 @@
 # Xpra is released under the terms of the GNU GPL v2, or, at your option, any
 # later version. See the file COPYING for details.
 
+import importlib
+import os
 from typing import Any, Sequence
 
 from xpra.util.objects import typedict
@@ -103,6 +105,28 @@ def torch_init() -> None:
             cuda_info["devices"] = devices
 
 
+def _load_py_transform(transform_str: str) -> tuple[Any, dict]:
+    """Load an external callable via 'py:<module>:<Class>(kwargs...)'."""
+    rest = transform_str[len("py:"):]
+    if ":" not in rest:
+        raise ValueError(
+            f"Invalid py: transform {transform_str!r}. "
+            "Expected format: py:<module>:<callable>(kwargs...)"
+        )
+    module_path, callable_part = rest.split(":", 1)
+    callable_name, kwargs = parse_function_call(callable_part)
+    log.info("py: loader: importing %r.%r kwargs=%s", module_path, callable_name, kwargs)
+    try:
+        mod = importlib.import_module(module_path)
+    except ImportError as exc:
+        raise ImportError(
+            f"Cannot import {module_path!r} for py: transform. "
+            f"Install the package or set PYTHONPATH. Error: {exc}"
+        ) from exc
+    factory = getattr(mod, callable_name)
+    return factory(**kwargs), {}
+
+
 class Filter:
     __slots__ = ("closed", "width", "height", "device", "transform", "kwargs")
 
@@ -124,7 +148,14 @@ class Filter:
         self.width = src_width
         self.height = src_height
         self.device = "cuda"
-        transform_str = options.strget("transform", "functional.invert")
+        transform_str = (
+            options.strget("transform")
+            or os.environ.get("XPRA_IMAGEFILTER_TRANSFORM", "functional.invert")
+        )
+        if transform_str.startswith("py:"):
+            self.transform, self.kwargs = _load_py_transform(transform_str)
+            log("init_context: loaded py: transform %r", self.transform)
+            return
         import torchvision.transforms.v2 as transforms
         if transform_str.startswith("functional."):
             functional = transforms.functional
@@ -174,12 +205,11 @@ class Filter:
     def get_type(self) -> str:
         return "torch"
 
-    def convert_image(self, image: ImageWrapper) -> ImageWrapper:
+    def convert_image(self, image: ImageWrapper, last_scroll_event: float = 0) -> ImageWrapper:
         width = image.get_width()
         height = image.get_height()
         assert width <= self.width, "expected image width smaller than %i got %i" % (self.width, width)
         assert height <= self.height, "expected image height smaller than %i got %i" % (self.height, height)
-        import torch
         import numpy as np
         rowstride = image.get_rowstride()
         bgrx = image.get_pixels()
@@ -187,24 +217,47 @@ class Filter:
         bgrx_array = np.frombuffer(bgrx, dtype=np.uint8)
         bgrx_array = bgrx_array.reshape(height, rowstride)
         bgrx_array = bgrx_array[:, :width * 4].reshape(height, width, 4)
+
+        if getattr(self.transform, "supports_numpy", False):
+            bgr_np = bgrx_array[:, :, :3].copy()
+            bgr_result = self.transform.process_numpy(
+                bgr_np,
+                target_x=getattr(image, "get_target_x", lambda: 0)(),
+                target_y=getattr(image, "get_target_y", lambda: 0)(),
+                window_width=self.width,
+                window_height=self.height,
+                scroll_event_time=last_scroll_event,
+                last_scroll_event=last_scroll_event,
+            )
+            result = np.concatenate([bgr_result, bgrx_array[:, :, 3:4]], axis=2)
+            bgrx_out = np.ascontiguousarray(result).tobytes()
+            filtered = ImageWrapper(
+                image.get_x(), image.get_y(), width, height,
+                bgrx_out, image.get_pixel_format(), image.get_depth(),
+                width * 4, 4, planes=ImageWrapper.PACKED, thread_safe=True,
+            )
+            filtered.set_target_x(image.get_target_x())
+            filtered.set_target_y(image.get_target_y())
+            return filtered
+
+        import torch
         pixels_gpu = torch.tensor(bgrx_array, device=self.device, dtype=torch.uint8)
-        # Separate BGR and X channels
-        bgr = pixels_gpu[:, :, :3]          # (H, W, 3)
-        x_channel = pixels_gpu[:, :, 3:4]   # (H, W, 1)
-        # Convert to CHW format for torchvision (C, H, W)
-        bgr_chw = bgr.permute(2, 0, 1)  # (3, H, W)
-        # Apply transform - RandomInvert works with uint8
+        bgr = pixels_gpu[:, :, :3]
+        x_channel = pixels_gpu[:, :, 3:4]
+        bgr_chw = bgr.permute(2, 0, 1)
         bgr_transformed = self.transform(bgr_chw, **self.kwargs)
-        # Convert back to HWC format
-        bgr_hwc = bgr_transformed.permute(1, 2, 0)  # (H, W, 3)
-        # Recombine with X channel
-        result_gpu = torch.cat([bgr_hwc, x_channel], dim=2)  # (H, W, 4)
-        # Download to CPU
+        bgr_hwc = bgr_transformed.permute(1, 2, 0)
+        result_gpu = torch.cat([bgr_hwc, x_channel], dim=2)
         result_cpu = result_gpu.cpu().numpy()
-        bgrx = result_cpu.tobytes()
-        image.set_pixels(bgrx)
-        image.set_rowstride(width * 4)
-        return image
+        bgrx_out = np.ascontiguousarray(result_cpu).tobytes()
+        filtered = ImageWrapper(
+            image.get_x(), image.get_y(), width, height,
+            bgrx_out, image.get_pixel_format(), image.get_depth(),
+            width * 4, 4, planes=ImageWrapper.PACKED, thread_safe=True,
+        )
+        filtered.set_target_x(image.get_target_x())
+        filtered.set_target_y(image.get_target_y())
+        return filtered
 
 
 def selftest(full=False):

--- a/xpra/server/source/image_filter.py
+++ b/xpra/server/source/image_filter.py
@@ -35,7 +35,7 @@ class NoFilter:
         return "NoFilter"
 
     @staticmethod
-    def process_image(image: ImageWrapper, callback: Callable[[ImageWrapper], None]) -> None:
+    def process_image(image: ImageWrapper, callback: Callable[[ImageWrapper], None], last_scroll_event: float = 0) -> None:
         callback(image)
 
     def clean(self) -> None:
@@ -52,24 +52,24 @@ class ImageFilter:
         self.thread = None
         log("ImageFilter(%#x, %s) filter_type=%s, threaded=%s", wid, imagefilter, filter_type, self.threaded)
 
-    def process_image(self, image: ImageWrapper, callback: Callable[[ImageWrapper], None]) -> None:
+    def process_image(self, image: ImageWrapper, callback: Callable[[ImageWrapper], None], last_scroll_event: float = 0) -> None:
         log("%s.process_image(%s, %s) enabled=%s", self, image, callback, self.enabled)
         if not self.enabled:
             callback(image)
             return
         if not self.threaded:
-            self.do_process_image(image, callback)
+            self.do_process_image(image, callback, last_scroll_event)
             return
         if not self.wait_for_thread():
             free_image_wrapper(image)
             return
         self.thread = start_thread(self.do_process_image, "image-filter-process-image-%#x" % self.wid,
-                                   daemon=True, args=(image, callback))
+                                   daemon=True, args=(image, callback, last_scroll_event))
 
-    def do_process_image(self, image: ImageWrapper, callback: Callable[[ImageWrapper], None]) -> None:
+    def do_process_image(self, image: ImageWrapper, callback: Callable[[ImageWrapper], None], last_scroll_event: float = 0) -> None:
         if DELAY > 0:
             sleep(DELAY / 1000)
-        filtered = self.filter.convert_image(image)
+        filtered = self.filter.convert_image(image, last_scroll_event=last_scroll_event)
         free_image_wrapper(image)
         callback(filtered)
 

--- a/xpra/server/subsystem/keyboard.py
+++ b/xpra/server/subsystem/keyboard.py
@@ -11,6 +11,7 @@ from time import monotonic
 from xpra.net.constants import ConnectionMessage
 from xpra.os_util import gi_import
 from xpra.server.source.keyboard import KeyboardConnection
+from xpra.util.env import envbool
 from xpra.util.str_fn import Ellipsizer, csv
 from xpra.util.objects import typedict
 from xpra.keyboard.common import DELAY_KEYBOARD_DATA
@@ -23,6 +24,24 @@ from xpra.log import Logger
 GLib = gi_import("GLib")
 
 log = Logger("keyboard")
+
+# Keyboard-as-scroll heuristic: certain keypresses (PageDown, arrow keys, etc.)
+# almost always cause the focused window's content to scroll vertically.
+# Treat their press as a scroll event for downstream consumers (chiefly the
+# OCR/PII temporal merger) so masks don't go stale while the page is moving.
+# Auto-repeat naturally re-emits while the key is held, which keeps the merger
+# in suppress mode for the entire scroll duration.
+#
+#   XPRA_KEYBOARD_SCROLL_ENABLED  master switch
+#
+# Conservative key set: avoids Space (typing collisions) and Left/Right
+# (rare for vertical scrolling, common in text editing).
+KEYBOARD_SCROLL_ENABLED = envbool("XPRA_KEYBOARD_SCROLL_ENABLED", True)
+KEYBOARD_SCROLL_KEYNAMES: frozenset[str] = frozenset({
+    "Page_Up", "Page_Down", "Prior", "Next",
+    "Home", "End",
+    "Up", "Down",
+})
 
 
 class KeyboardServer(StubServerMixin):
@@ -288,6 +307,18 @@ class KeyboardServer(StubServerMixin):
                 log.estr(e)
                 log.error(" for keyname=%s, keyval=%i, keycode=%i", keyname, keyval, keycode)
         ss.emit("user-event", "key-action")
+        # Keyboard-as-scroll: notify window sources so the OCR/PII temporal
+        # merger treats this frame range as 'actively scrolling'.
+        if KEYBOARD_SCROLL_ENABLED and pressed and wid and keyname in KEYBOARD_SCROLL_KEYNAMES:
+            log("keyboard-as-scroll: wid=%i keyname=%r", wid, keyname)
+            try:
+                window_sources = self.window_sources()
+            except AttributeError:
+                window_sources = ()
+            for ws in window_sources:
+                rec = getattr(ws, "record_scroll_event", None)
+                if rec:
+                    rec(wid)
 
     def get_keycode(self, ss, client_keycode: int, keyname: str,
                     pressed: bool, modifiers: list[str], keyval: int, keystr: str, group: int):

--- a/xpra/server/subsystem/pointer.py
+++ b/xpra/server/subsystem/pointer.py
@@ -5,11 +5,12 @@
 # later version. See the file COPYING for details.
 # pylint: disable-msg=E1101
 
+from time import monotonic
 from typing import Any
 from collections.abc import Sequence
 
 from xpra.server.source.pointer import PointerConnection
-from xpra.util.env import envbool
+from xpra.util.env import envbool, envint
 from xpra.util.objects import typedict
 from xpra.os_util import gi_import
 from xpra.net.common import Packet, PacketElement, BACKWARDS_COMPATIBLE
@@ -23,6 +24,37 @@ GLib = gi_import("GLib")
 
 INPUT_SEQ_NO = envbool("XPRA_INPUT_SEQ_NO", False)
 ALWAYS_NOTIFY_MOTION = envbool("XPRA_ALWAYS_NOTIFY_MOTION", False)
+
+# Drag-as-scroll heuristic: when button-1 is held on a window and the pointer
+# moves vertically, treat the motion as a scroll event for downstream consumers
+# (chiefly the OCR/PII temporal merger, which otherwise only learns about wheel
+# events).  Two complementary signals are used to separate scrollbar-thumb drags
+# from text-selection and other button-1 drags:
+#   (a) press-X close to the right edge of the window (scrollbar zone), and
+#   (b) the drag motion remains near-vertical (low |dx|:|dy| ratio).
+# (a) is the strong signal when window geometry is available.  (b) is the
+# fallback when geometry can't be resolved.  Either signal classifying the
+# drag as 'not a scrollbar drag' suppresses emits for the rest of that drag.
+#
+#   XPRA_DRAG_SCROLL_ENABLED                  master switch
+#   XPRA_DRAG_SCROLL_MIN_DY_PX                cumulative |dy| (px) before emit
+#   XPRA_DRAG_SCROLL_EMIT_INTERVAL_MS         minimum gap between emits per drag
+#   XPRA_DRAG_SCROLLBAR_ZONE_PX               width (px) of the right-edge zone
+#                                             treated as the scrollbar (~chromium
+#                                             default scrollbar width + margin)
+#   XPRA_DRAG_SCROLL_SELECTION_PROBE_DY_PX    accumulated |dy| at which the dx/dy
+#                                             ratio is first evaluated; below this
+#                                             motion is considered too short to
+#                                             classify reliably
+#   XPRA_DRAG_SCROLL_SELECTION_DX_PCT         % of |dy| that |dx| may reach before
+#                                             the drag is latched as selection-like
+#                                             (only consulted when zone is unknown)
+DRAG_SCROLL_ENABLED = envbool("XPRA_DRAG_SCROLL_ENABLED", True)
+DRAG_SCROLL_MIN_DY_PX = envint("XPRA_DRAG_SCROLL_MIN_DY_PX", 4)
+DRAG_SCROLL_EMIT_INTERVAL_MS = envint("XPRA_DRAG_SCROLL_EMIT_INTERVAL_MS", 50)
+DRAG_SCROLLBAR_ZONE_PX = envint("XPRA_DRAG_SCROLLBAR_ZONE_PX", 20)
+DRAG_SCROLL_SELECTION_PROBE_DY_PX = envint("XPRA_DRAG_SCROLL_SELECTION_PROBE_DY_PX", 6)
+DRAG_SCROLL_SELECTION_DX_PCT = envint("XPRA_DRAG_SCROLL_SELECTION_DX_PCT", 40)
 
 
 class PointerServer(StubServerMixin):
@@ -43,6 +75,17 @@ class PointerServer(StubServerMixin):
         self.touchpad_device = None
         self.double_click_time = -1
         self.double_click_distance = -1, -1
+        # Per-window state for the drag-as-scroll heuristic.
+        # Keyed by wid (not device_id) because legacy v4 protocol paths use
+        # different device_id defaults for press (0) vs motion (-1), which
+        # would otherwise miss every drag.  Each entry:
+        #   {"last_x": int, "last_y": int,
+        #    "accum_dx_abs": int, "accum_dy_abs": int,
+        #    "in_scrollbar_zone": bool|None,    # None = window geom unknown
+        #    "looks_like_selection": bool,      # latched once True
+        #    "last_emit_t_ms": float}
+        # Populated on button-1 press, consumed on motion, cleared on release.
+        self._button1_drag: dict[int, dict] = {}
         # duplicated:
         self.readonly = False
 
@@ -321,11 +364,138 @@ class PointerServer(StubServerMixin):
                                  pointer, props: dict) -> None:
         if "modifiers" in props:
             self._update_modifiers(proto, wid, props.get("modifiers", ()))
+        if DRAG_SCROLL_ENABLED and button == 1 and wid:
+            if pressed:
+                self._button1_drag[wid] = self._make_button1_drag_state(wid, pointer)
+            else:
+                self._button1_drag.pop(wid, None)
         props = {}
         if self.process_mouse_common(proto, device_id, wid, pointer, props):
             seq = self.pointer_sequence.get(device_id, 0)
             self.may_record_pointer_event("pointer-button", device_id, seq, wid, button, pressed, pointer, props)
             self.button_action(device_id, wid, button, pressed, props)
+
+    def _make_button1_drag_state(self, wid: int, pointer) -> dict:
+        """Snapshot the button-1 press for the drag-as-scroll heuristic.
+
+        Computes whether the press landed inside the window's right-edge
+        scrollbar zone, using the window-relative x (``pointer[2]``) and the
+        window's geometry width when reachable.  Stores press coordinates so
+        the motion handler can accumulate dx/dy.
+        """
+        try:
+            press_x = int(pointer[0]) if pointer and len(pointer) >= 1 else 0
+            press_y = int(pointer[1]) if pointer and len(pointer) >= 2 else 0
+        except (TypeError, ValueError):
+            press_x, press_y = 0, 0
+        in_zone: bool | None = None
+        rel_x: int | None = None
+        if pointer and len(pointer) >= 4:
+            try:
+                rel_x = int(pointer[2])
+            except (TypeError, ValueError):
+                rel_x = None
+        window_width = self._lookup_window_width(wid)
+        if rel_x is not None and window_width:
+            in_zone = (window_width - rel_x) <= DRAG_SCROLLBAR_ZONE_PX
+        return {
+            "last_x": press_x,
+            "last_y": press_y,
+            "accum_dx_abs": 0,
+            "accum_dy_abs": 0,
+            "in_scrollbar_zone": in_zone,
+            "looks_like_selection": False,
+            "last_emit_t_ms": 0.0,
+        }
+
+    def _lookup_window_width(self, wid: int) -> int | None:
+        """Return the width of the window with id ``wid``, or ``None``.
+
+        Mirrors the geometry lookup in :meth:`_get_pointer_abs_coordinates`:
+        only works when this mixin is composed with :class:`WindowServer`
+        (i.e. on the X11 server) and the window model is reachable.
+        """
+        try:
+            from xpra.server.subsystem.window import WindowServer
+        except ImportError:
+            return None
+        if not isinstance(self, WindowServer):
+            return None
+        try:
+            model = self.get_window(wid)
+            if not model:
+                return None
+            geom = model.get_geometry()
+        except Exception:
+            return None
+        if not geom or len(geom) < 4:
+            return None
+        try:
+            return int(geom[2])
+        except (TypeError, ValueError):
+            return None
+
+    def _maybe_record_drag_scroll(self, device_id: int, wid: int, pdata) -> None:
+        """Treat sustained button-1 + near-vertical motion as a scroll event.
+
+        Distinguishes scrollbar-thumb drags from text-selection drags using
+        two complementary signals: (a) press inside the window's right-edge
+        scrollbar zone (strong, used when window geometry is reachable) and
+        (b) accumulated |dx| vs |dy| ratio (fallback, used when geometry is
+        unknown or as additional confidence).  A drag classified as anything
+        other than a scrollbar drag has emits suppressed for its remaining
+        lifetime.
+
+        Keyed on ``wid`` (not ``device_id``) because the legacy v4 protocol
+        paths used by the bundled HTML5 client deliver press with
+        ``device_id=0`` and motion with ``device_id=-1``; keying on wid
+        sidesteps that mismatch.  Otherwise rate-limited per drag via
+        ``DRAG_SCROLL_MIN_DY_PX`` and ``DRAG_SCROLL_EMIT_INTERVAL_MS``.
+        """
+        if not DRAG_SCROLL_ENABLED or not wid:
+            return
+        drag = self._button1_drag.get(wid)
+        if not drag or len(pdata) < 2:
+            return
+        try:
+            cur_x = int(pdata[0])
+            cur_y = int(pdata[1])
+        except (TypeError, ValueError):
+            return
+        drag["accum_dx_abs"] += abs(cur_x - drag["last_x"])
+        drag["accum_dy_abs"] += abs(cur_y - drag["last_y"])
+        drag["last_x"] = cur_x
+        drag["last_y"] = cur_y
+        # Strong reject: press was clearly not on the scrollbar.
+        if drag["in_scrollbar_zone"] is False:
+            return
+        # Fallback signal (only when zone is unknown): motion-direction.
+        # Once the ratio crosses the threshold we latch the drag as
+        # selection-like so a later returns-to-vertical micro-movement
+        # doesn't reopen the emit gate.
+        if drag["in_scrollbar_zone"] is None and not drag["looks_like_selection"]:
+            if (drag["accum_dy_abs"] >= DRAG_SCROLL_SELECTION_PROBE_DY_PX
+                    and drag["accum_dx_abs"] * 100
+                        >= DRAG_SCROLL_SELECTION_DX_PCT * drag["accum_dy_abs"]):
+                drag["looks_like_selection"] = True
+                log("drag-as-scroll: wid=%i classified as selection-like "
+                    "(unknown zone, dx=%i dy=%i)",
+                    wid, drag["accum_dx_abs"], drag["accum_dy_abs"])
+        if drag["looks_like_selection"]:
+            return
+        # Pixel threshold + rate limit.
+        if drag["accum_dy_abs"] < DRAG_SCROLL_MIN_DY_PX:
+            return
+        now_ms = monotonic() * 1000.0
+        if (now_ms - drag["last_emit_t_ms"]) < DRAG_SCROLL_EMIT_INTERVAL_MS:
+            return
+        drag["last_emit_t_ms"] = now_ms
+        drag["accum_dx_abs"] = 0
+        drag["accum_dy_abs"] = 0
+        log("drag-as-scroll: wid=%i y=%i zone=%s",
+            wid, cur_y, drag["in_scrollbar_zone"])
+        for ss in self.window_sources():
+            ss.record_scroll_event(wid)
 
     def button_action(self, device_id: int, wid: int, button: int, pressed: bool, props: dict) -> None:
         device = self.get_pointer_device(device_id)
@@ -365,6 +535,7 @@ class PointerServer(StubServerMixin):
             modifiers = props.get("modifiers")
             if modifiers is not None:
                 self._update_modifiers(proto, wid, modifiers)
+        self._maybe_record_drag_scroll(device_id, wid, pdata)
 
     def _process_pointer_position(self, proto, packet: Packet) -> None:
         log("_process_pointer_position(%s, %s) readonly=%s, ui_driver=%s",
@@ -390,6 +561,7 @@ class PointerServer(StubServerMixin):
             device_id = packet[5]
         if self.process_mouse_common(proto, device_id, wid, pdata, props):
             self._update_modifiers(proto, wid, modifiers)
+        self._maybe_record_drag_scroll(device_id, wid, pdata)
 
     def _process_pointer_wheel(self, proto, packet: Packet) -> None:
         assert self.pointer_device.has_precise_wheel()

--- a/xpra/server/window/compress.py
+++ b/xpra/server/window/compress.py
@@ -2159,7 +2159,7 @@ class WindowSource(WindowIconSource):
         def process_damage_image(img: ImageWrapper) -> None:
             self.process_damage_image(damage_time, rgb_request_time, img, coding, sequence, options, flush)
 
-        self.image_filter.process_image(image, process_damage_image)
+        self.image_filter.process_image(image, process_damage_image, last_scroll_event=self.last_scroll_event)
 
     def process_damage_image(self, damage_time: float, rgb_request_time: float,
                              image: ImageWrapper,


### PR DESCRIPTION


xpra/codecs/pytorch/filter.py
  * accept transform option 'py:<module>:<Class>(kw=val,...)'; load via importlib and call into the resulting object's process_numpy(bgr, **kwargs) when it sets supports_numpy = True (CPU fast path).
  * thread last_scroll_event through convert_image and into the numpy callback.
  * return a *new* ImageWrapper in both the numpy and torchvision paths instead of mutating the input. xpra r40561's threaded image filter frees the input wrapper after convert_image() returns, so mutating-then-returning caused a use-after-free.
  * rowstride-safe BGRX reshape (stride > width*4 paths).
  * XPRA_IMAGEFILTER_TRANSFORM env fallback for the option default.

xpra/server/source/image_filter.py + xpra/server/window/compress.py
  * thread WindowSource.last_scroll_event through ImageFilter.process_ image / do_process_image and into convert_image.

xpra/server/subsystem/pointer.py
  * derive a scroll-hint signal from button-1 drags and call each window source's record_scroll_event(wid). Press-time scrollbar zone (right edge of window, XPRA_DRAG_SCROLLBAR_ZONE_PX) is the strong signal; when window geometry isn't reachable, accumulated |dx|/|dy| ratio is used as a fallback to suppress text-selection drags. Rate-limited per drag (XPRA_DRAG_SCROLL_MIN_DY_PX, XPRA_DRAG_SCROLL_EMIT_INTERVAL_MS). XPRA_DRAG_SCROLL_ENABLED gates the feature, on by default.

xpra/server/subsystem/keyboard.py
  * emit the scroll-hint signal on Page_Up/Page_Down, Home/End and Up/Down key presses (XPRA_KEYBOARD_SCROLL_ENABLED, on by default). Auto-repeat keeps the signal flowing while a key is held.

The downstream use case is an OCR-based PII masking filter that needs to know when content is actively scrolling so it can suspend re-anchoring of confirmed match regions and avoid visible mask lag. Existing torchvision/functional transforms are unaffected; new env vars all default to enabled but flip off cleanly.