### PR TITLE
opengl: optional resize_fbo glFinish() workaround for driver bug

### DIFF
--- a/xpra/opengl/backing.py
+++ b/xpra/opengl/backing.py
@@ -34,7 +34,7 @@ from OpenGL.GL import (
     glViewport,
     glGenTextures, glDeleteTextures,
     glDisable,
-    glBindTexture, glPixelStorei, glFlush,
+    glBindTexture, glPixelStorei, glFlush, glFinish,
     glBindBuffer, glGenBuffers, glBufferData, glDeleteBuffers,
     glTexParameteri,
     glTexImage2D,
@@ -86,6 +86,14 @@ FORCE_VIDEO_PIXEL_FORMAT = tuple(x.strip() for x in os.environ.get("XPRA_FORCE_V
 DRAW_REFRESH = envbool("XPRA_OPENGL_DRAW_REFRESH", True)
 FBO_RESIZE = envbool("XPRA_OPENGL_FBO_RESIZE", True)
 FBO_RESIZE_DELAY = envint("XPRA_OPENGL_FBO_RESIZE_DELAY", -1)
+# When set, forces a glFinish() at three commit points in resize_fbo.
+# Workaround for drivers that fail to honor in-order visibility across
+# the swap-and-reinit dance, producing a stretched + black-bar artifact
+# after a fast resize. Default on; cost is negligible on healthy drivers
+# (no GPU work queued at the commit points) but eliminates the artifact
+# on affected ones.
+# See https://gitlab.freedesktop.org/mesa/mesa/-/issues/15513
+RESIZE_GLFINISH = envbool("XPRA_OPENGL_RESIZE_GLFINISH", True)
 CONTEXT_REINIT = envbool("XPRA_OPENGL_CONTEXT_REINIT", False)
 NVJPEG = envbool("XPRA_OPENGL_NVJPEG", True)
 NVDEC = envbool("XPRA_OPENGL_NVDEC", False)
@@ -410,8 +418,12 @@ class GLWindowBackingBase(WindowBackingBase):
         self.draw_to_tmp()
         glClearColor(0, 0, 0, 1)
         glClear(GL_COLOR_BUFFER_BIT)
+        if RESIZE_GLFINISH:
+            glFinish()
         # copy offscreen to new tmp:
         self.copy_fbo(w, h, sx, sy, dx, dy)
+        if RESIZE_GLFINISH:
+            glFinish()
         # make tmp the new offscreen:
         self.swap_fbos()
         self.draw_to_offscreen()
@@ -423,6 +435,8 @@ class GLWindowBackingBase(WindowBackingBase):
         # and we can re-initialize it with the correct size:
         mag_filter = self.get_init_magfilter()
         self.init_fbo(TEX_TMP_FBO, self.tmp_fbo, bw, bh, mag_filter)
+        if RESIZE_GLFINISH:
+            glFinish()
         self._backing.queue_draw_area(0, 0, bw, bh)
         if FBO_RESIZE_DELAY >= 0:
             del context


### PR DESCRIPTION
## Summary

Some drivers — most notably Mesa's `d3d12` gallium driver shipped via Microsoft GLOn12 on Windows ARM64 — defer texture storage allocation across the swap-and-reinit dance in `resize_fbo` and end up sampling the previous-size resource on the next render, producing a stretched + black-bar artifact after a fast window resize. Per the OpenGL spec the driver must guarantee in-order visibility automatically, so this is strictly a workaround for non-conforming behavior.

This PR inserts `glFinish()` at three commit points in `resize_fbo`:

1. **After the new-size tmp FBO's texture is reallocated and cleared, before the blit reads it** (forces the new-size storage to materialize on the driver side).
2. **After `glBlitFramebuffer` from old offscreen → new-size tmp, before the pointer-swap** (forces the blit to complete before subsequent ops treat the swapped FBO as the new offscreen).
3. **After the final `glTexImage2D` reallocates the new tmp at the new size, before returning** (forces that final realloc to commit before the next frame's render pass references it).

Gated by `XPRA_OPENGL_RESIZE_GLFINISH`, **default on**. The cost on healthy drivers is negligible (no GPU work is queued at these specific commit points, so each `glFinish()` returns in microseconds); on the affected driver stack the total overhead is ~3-5ms per resize event and eliminates the artifact.

See https://gitlab.freedesktop.org/mesa/mesa/-/issues/15513 for the upstream Mesa bug this works around.

## Empirical justification for the workaround choice

Isolated to CPU-side driver state (not GPU command ordering) via an A/B test of three sync primitives at the same three commit points, measured on Snapdragon X Elite + Adreno X1-85 + Mesa d3d12 26.2.0-devel:

| Primitive | Per-call cost | Total resize | Bug? |
|---|---|---|---|
| `glFinish()` | ~3ms / ~1-2ms / sub-ms | ~22-24ms | **Fixed** |
| `glFenceSync` + `glClientWaitSync` | ~2.5ms / ~1-2ms / sub-ms | ~22-25ms | **Fixed** |
| `glMemoryBarrier(GL_TEXTURE_UPDATE_BARRIER_BIT)` | ~0.5ms / ~0.3ms / sub-ms | ~19-22ms | Not fixed |
| No sync (baseline) | — | ~20ms | Not fixed |

Both CPU-blocking primitives fix it; the GPU-side memory barrier (spec-correct for "texture writes visible before subsequent reads") does not. Strong fingerprint for a CPU-side bookkeeping bug in the driver. `glFinish` is the simplest of the two working primitives and equivalent in cost.

## Compatibility

No behavior change observable on healthy drivers (the 3 `glFinish()` calls are essentially no-ops where there's no queued GPU work to drain). On the affected Mesa-`d3d12`/Adreno stack the artifact is eliminated at the cost of a few ms per resize event.

The `props["version"]` change that was originally bundled here has been split out into a separate PR per reviewer request.

Sponsored-By: Netflix