### PR TITLE
nvenc: prevent use-after-free SEGV in Encoder __dealloc__

### DIFF
--- a/tests/scripts/nvenc_dealloc_uaf_repro.py
+++ b/tests/scripts/nvenc_dealloc_uaf_repro.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+# This file is part of Xpra.
+# Copyright (C) 2026 Netflix, Inc.
+# Xpra is released under the terms of the GNU GPL v2, or, at your option, any
+# later version. See the file COPYING for details.
+# ABOUTME: Reproducer for nvenc Encoder __dealloc__ use-after-free.
+# ABOUTME: Drops the only ref to an inited Encoder; __dealloc__ spawns
+# ABOUTME: threaded_clean via start_thread; the thread reads freed self.
+
+"""
+Reproducer for the nvenc Encoder use-after-free hypothesis (see
+`nvenc-segv-hypothesis.md`).
+
+Setup:
+    1. Subprocess inits NVENC and creates ONE fully-initialized Encoder.
+    2. Subprocess drops the only ref via `enc = None`.
+       Refcount drops 1 → 0. Cython `__dealloc__` fires.
+       __dealloc__ sees `self.closed == False` → calls `self.clean()`.
+       clean() spawns `threaded_clean` via `start_thread`.
+       The bound method captures `self` → refcount 0 → 1.
+       __dealloc__ returns. Cython tp_dealloc continues to free the struct
+       (no resurrection check in Cython cdef class tp_dealloc).
+    3. Main thread sleeps long enough for `threaded_clean` to run.
+       threaded_clean does `self.init_complete` and `self.do_clean()` — both
+       read freed memory. If memory was reused, SEGV.
+    4. Subprocess exits cleanly. Parent inspects exit code.
+
+Outcome interpretation:
+    - exit code == -11 (or 139): SEGV → hypothesis CONFIRMED.
+    - exit code == 0 and no SEGV: hypothesis not reproduced under this run.
+      Could mean (a) Cython actually handles resurrection, (b) memory not
+      reused in the race window, or (c) something else holds the encoder
+      alive that I missed. Run multiple times to estimate hit rate.
+    - exit code != 0 and != -11: infra error.
+
+Differences from `nvenc_cleanup_repro.py`:
+    - That reproducer calls `enc.clean()` EXPLICITLY and tests the cleanup
+      LEAK path (out-of-thread context warnings). This one does NOT call
+      clean(); it drops the ref and lets __dealloc__ fire — that's the path
+      under investigation.
+    - That reproducer uses `os._exit(0)` to terminate the subprocess
+      quickly. This one does NOT — we need the subprocess to live long
+      enough for the spawned threaded_clean to execute and (potentially)
+      access freed memory.
+
+Usage:
+    /usr/bin/python3 tests/scripts/nvenc_dealloc_uaf_repro.py
+    /usr/bin/python3 tests/scripts/nvenc_dealloc_uaf_repro.py --runs=10
+
+The default is 5 runs because the race is timing-dependent — one run may
+or may not trigger the SEGV depending on whether freed memory has been
+overwritten by the time threaded_clean reads from it.
+"""
+
+import argparse
+import os
+import signal
+import subprocess
+import sys
+import time
+
+
+# How long the worker waits after dropping the encoder ref. The spawned
+# `threaded_clean` thread needs time to wake up, schedule, run, and try
+# to access freed memory. 3s is generous — typical thread scheduling
+# latency is <1ms but we want to allow for GIL contention and gc.
+WORKER_WAIT_SECONDS = 3.0
+
+
+# --------------------------- WORKER (subprocess) ---------------------------
+
+def worker_main(args: argparse.Namespace) -> int:
+    """Runs inside the subprocess. Builds an encoder, drops the only ref,
+    waits for the use-after-free to potentially fire, exits."""
+    import threading
+    import gc
+
+    print(f"[worker pid={os.getpid()}] starting", file=sys.stderr, flush=True)
+
+    from xpra.codecs.nvidia.cuda.context import (
+        init_all_devices, load_device, cuda_device_context,
+    )
+    from xpra.codecs.nvidia.nvenc import encoder as nvenc_encoder
+    from xpra.codecs.image import ImageWrapper
+    from xpra.util.objects import typedict
+
+    nvenc_encoder.init_module({})
+    devices = init_all_devices()
+    if not devices:
+        print("FAIL: no CUDA devices", file=sys.stderr, flush=True)
+        return 2
+    device_id = devices[0]
+    device = load_device(device_id)
+    cdc = cuda_device_context(device_id, device)
+    with cdc:
+        pass  # prime context
+
+    W = H = 256
+    pixels = bytes(W * H * 4)
+
+    def make_image() -> ImageWrapper:
+        return ImageWrapper(
+            0, 0, W, H, pixels, "BGRX", 32, W * 4,
+            planes=ImageWrapper.PACKED, thread_safe=True,
+        )
+
+    # Build a fully-initialized Encoder.
+    # IMPORTANT: pass `threaded-init=True` so __dealloc__'s clean() path
+    # will call start_thread (which is the path under test). If
+    # threaded-init is False, clean() runs do_clean inline and the bug
+    # does not exist.
+    print("[worker] creating encoder with threaded-init=True",
+          file=sys.stderr, flush=True)
+    enc = nvenc_encoder.Encoder()
+    options = typedict({
+        "cuda-device-context": cdc,
+        "dst-formats": ("YUV420P", "YUV444P"),
+        "quality": 50, "speed": 50,
+        "threaded-init": True,
+    })
+    enc.init_context("h264", W, H, "BGRX", options)
+    # Wait for threaded_init to complete by polling is_ready(). The
+    # underlying init_complete Event is a cdef-private attribute so we
+    # can't wait on it directly from Python.
+    deadline = time.monotonic() + 10
+    while not enc.is_ready():
+        if time.monotonic() >= deadline:
+            print("FAIL: encoder not ready within 10s", file=sys.stderr, flush=True)
+            return 3
+        time.sleep(0.05)
+    # Push a frame through so the encoder is fully wired.
+    try:
+        enc.compress_image(make_image(),
+                           typedict({"cuda-device-context": cdc}))
+    except Exception as e:
+        print(f"[worker] compress_image raised: {e!r}", file=sys.stderr, flush=True)
+
+    print(f"[worker] encoder built: {enc!r}", file=sys.stderr, flush=True)
+    print(f"[worker] enc.closed = {enc.is_closed()}", file=sys.stderr, flush=True)
+
+    # CRITICAL SECTION: drop the only ref.
+    # `enc = None` decrefs the bound name. If `enc` was the only strong
+    # reference, the Encoder's refcount hits 0 and __dealloc__ fires
+    # synchronously here. __dealloc__ sees `self.closed == False`, calls
+    # self.clean(), which spawns `threaded_clean` via start_thread,
+    # which captures `self` in a bound method, resurrecting refcount to 1.
+    # But Cython's tp_dealloc proceeds to free the struct anyway.
+    # The spawned thread now holds a bound method whose __self__ points
+    # at freed memory.
+    print("[worker] dropping encoder ref now (this triggers __dealloc__)",
+          file=sys.stderr, flush=True)
+    sys.stderr.flush()
+    enc = None
+
+    # Force a GC pass to drive home any cycles. Shouldn't be needed for
+    # a plain reference drop, but include for completeness.
+    gc.collect()
+
+    # Wait for the spawned threaded_clean to (try to) access self.
+    # During this sleep, any of the following happens (mutually exclusive):
+    #   1. threaded_clean runs, reads self.init_complete from freed memory,
+    #      SEGV fires. Process dies with signal 11.
+    #   2. threaded_clean runs, reads stale-but-coherent freed memory,
+    #      runs through cleanup, possibly succeeds. No SEGV.
+    #   3. threaded_clean is queued but not yet scheduled; we exit before
+    #      it runs. No SEGV (false negative).
+    print(f"[worker] sleeping {WORKER_WAIT_SECONDS}s waiting for threaded_clean",
+          file=sys.stderr, flush=True)
+    time.sleep(WORKER_WAIT_SECONDS)
+
+    print(f"[worker] survived sleep, threading enumerate={[t.name for t in threading.enumerate()]}",
+          file=sys.stderr, flush=True)
+    print("[worker] no SEGV observed in this run", file=sys.stderr, flush=True)
+    sys.stderr.flush()
+    sys.stdout.flush()
+    # Skip atexit: pycuda's shutdown path hangs when GPU resources are
+    # leaked (which the fix intentionally does, instead of SEGVing). All
+    # diagnostic output has already been printed.
+    os._exit(0)
+
+
+# --------------------------- PARENT (driver) ---------------------------
+
+def signal_label(rc: int) -> str:
+    """Convert a return code to a readable form. Negative = killed by signal."""
+    if rc >= 0:
+        return f"exited normally (rc={rc})"
+    sig = -rc
+    name = signal.Signals(sig).name if sig in signal.Signals._value2member_map_ else f"sig{sig}"
+    return f"killed by {name} (rc={rc})"
+
+
+def parent_main(args: argparse.Namespace) -> int:
+    """Spawns the worker N times, counts SEGVs."""
+    env = dict(os.environ)
+    env["XPRA_NVENC_DEALLOC_UAF_REPRO_CHILD"] = "1"
+    cmd = [sys.executable, os.path.abspath(__file__)]
+    print(f"[parent] command: {' '.join(cmd)}")
+    print(f"[parent] runs: {args.runs}")
+    print(f"[parent] worker wait: {WORKER_WAIT_SECONDS}s")
+
+    segvs = 0
+    cleans = 0
+    other = 0
+    for run in range(1, args.runs + 1):
+        print()
+        print(f"=========== run {run}/{args.runs} ===========")
+        sys.stdout.flush()
+        proc = subprocess.run(
+            cmd, env=env,
+            stdout=sys.stdout, stderr=sys.stderr,
+            timeout=WORKER_WAIT_SECONDS + 60,
+        )
+        rc = proc.returncode
+        print(f"[parent] run {run} {signal_label(rc)}")
+        # SIGSEGV is signal 11. subprocess returns -11 for signal 11.
+        if rc == -signal.SIGSEGV or rc == -signal.SIGBUS:
+            segvs += 1
+        elif rc == 0:
+            cleans += 1
+        else:
+            other += 1
+
+    print()
+    print("=" * 60)
+    print(f"[parent] SUMMARY across {args.runs} runs:")
+    print(f"[parent]   SEGV/BUS:    {segvs}")
+    print(f"[parent]   clean exits: {cleans}")
+    print(f"[parent]   other:       {other}")
+    if segvs > 0:
+        print(f"[parent] REPRO CONFIRMED — hypothesis fires {segvs}/{args.runs} times.")
+        return 1
+    if other > 0 or cleans == 0:
+        print(f"[parent] INFRASTRUCTURE ERROR — {other} runs failed without SEGV,")
+        print("[parent] {cleans} clean exits. NOT a valid REPRO NEGATIVE result.".format(cleans=cleans))
+        return 2
+    print("[parent] REPRO NEGATIVE — no SEGVs in this batch.")
+    print("[parent] Hypothesis not confirmed; could be:")
+    print("[parent]   (a) Cython handles resurrection (unlikely per docs)")
+    print("[parent]   (b) freed memory not reused in time window")
+    print("[parent]   (c) some other ref kept encoder alive")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    ap.add_argument("--runs", type=int, default=5,
+                    help="number of subprocess runs to drive (each builds 1 encoder)")
+    args = ap.parse_args()
+
+    if os.environ.get("XPRA_NVENC_DEALLOC_UAF_REPRO_CHILD"):
+        return worker_main(args)
+    return parent_main(args)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/xpra/codecs/nvidia/nvenc/encoder.pyx
+++ b/xpra/codecs/nvidia/nvenc/encoder.pyx
@@ -1129,8 +1129,28 @@ cdef class Encoder:
         return bool(self.closed)
 
     def __dealloc__(self):
+        # When threaded_init is on (the default), clean() spawns
+        # threaded_clean via start_thread, whose Thread retains a bound
+        # method holding self. Cython's tp_dealloc for a cdef class then
+        # frees the struct after __dealloc__ returns regardless of
+        # refcount resurrection, so the spawned thread dereferences
+        # freed memory and SEGVs. Callers MUST call clean() before
+        # dropping the last reference in that mode; if they don't, leak
+        # GPU resources rather than crash.
+        # When threaded_init is off, clean() runs do_clean() inline (no
+        # thread spawn, no UAF risk), so it's still safe to do the
+        # cleanup here.
         if not self.closed:
-            self.clean()
+            if self.threaded_init:
+                try:
+                    log.warn("Warning: nvenc Encoder %s GC'd without clean()", self)
+                    log.warn(" leaking GPU resources to avoid use-after-free —")
+                    log.warn(" call clean() before dropping the last reference")
+                except Exception:
+                    pass
+                self.closed = 1
+            else:
+                self.clean()
 
     def clean(self) -> None:
         f = self.file

--- a/xpra/server/encoder/server.py
+++ b/xpra/server/encoder/server.py
@@ -199,8 +199,22 @@ class EncoderServer(ServerBase):
                         log(f" supported pixel formats for {encoding!r}: %s", csv(input_cs_options))
                         raise ValueError(msg)
                 add_device_context(ss, options)
-                encoder.init_context(encoding, width, height, pixel_format, typedict(options))
-                bdata, client_options = encoder.compress_image(image, typedict(options))
+                try:
+                    encoder.init_context(encoding, width, height, pixel_format, typedict(options))
+                    bdata, client_options = encoder.compress_image(image, typedict(options))
+                finally:
+                    # Per-request one-shot encoder: clean explicitly so
+                    # GPU resources are released even if init_context or
+                    # compress_image raised. Relying on __dealloc__ is
+                    # unsafe — see nvenc Encoder.__dealloc__. Swallow
+                    # cleanup errors so we don't replace a successful
+                    # encode result (or mask the original exception).
+                    try:
+                        encoder.clean()
+                    except Exception:
+                        # NVENCException from raiseNVENC() inherits from
+                        # Exception (not RuntimeError), so catch broadly.
+                        log.error(f"Error cleaning one-shot encoder {encoder}", exc_info=True)
                 bpp = 24
                 stride = 0
                 coding = encoding

--- a/xpra/server/window/video_compress.py
+++ b/xpra/server/window/video_compress.py
@@ -27,6 +27,7 @@ from xpra.server.window.compress import (
     STRICT_MODE, LOSSLESS_WINDOW_TYPES,
     DOWNSCALE_THRESHOLD, DOWNSCALE, TEXT_QUALITY,
     LOG_ENCODERS,
+    MAX_SEQUENCE,
 )
 from xpra.net.common import Packet, BACKWARDS_COMPATIBLE
 from xpra.util.rectangle import rectangle, merge_all
@@ -370,8 +371,19 @@ class WindowVideoSource(WindowSource):
         self.cleanup_codecs()
 
     def cleanup(self) -> None:
+        # cancel_damage() in this class already calls cleanup_codecs(),
+        # which captures the encoder refs and schedules explicit clean()
+        # in the encode thread. It must run before super().cleanup()
+        # because the base class's cleanup() calls init_vars() —
+        # resolved (via Python method lookup) to our subclass override,
+        # which nulls _video_encoder and _csc_encoder. If init_vars
+        # runs first, video_context_clean() inside cleanup_codecs sees
+        # None refs and skips the explicit clean(); the encoder is then
+        # GC'd without closed=True, exposing the nvenc __dealloc__
+        # use-after-free path (defended by the companion commit, but
+        # better not to reach it at all).
+        self.cancel_damage(MAX_SEQUENCE)
         super().cleanup()
-        self.cleanup_codecs()
         self.stop_gstreamer_pipeline()
 
     def cleanup_codecs(self) -> None:


### PR DESCRIPTION
## Summary

Fix two latent bugs in nvenc Encoder cleanup that combine to cause server SIGSEGV under encoder reinit pressure (observed live on a 4:4:4 HEVC workload):

1. **`Encoder.__dealloc__` use-after-free.** When `threaded_init` is on (the default), `__dealloc__` called `self.clean()`, which spawns `threaded_clean` via `start_thread`. The Thread retains a bound method holding `self`, but Cython's `tp_dealloc` for a cdef class frees the struct after `__dealloc__` returns regardless of refcount resurrection. The spawned thread then dereferences freed memory → SEGV.

2. **`WindowVideoSource.cleanup()` ordering.** `super().cleanup()` ran first, which invokes `init_vars()` (Python method lookup resolves to the subclass override, nulling `self._video_encoder` / `_csc_encoder`). The follow-up `cleanup_codecs()` then saw `None` and skipped the explicit `clean()` call — putting the encoder onto the `__dealloc__` UAF path above.

## Changes

### `server: clean codecs before init_vars in WindowVideoSource.cleanup`
Reorder `cleanup()` so `cancel_damage(MAX_SEQUENCE)` runs first. `cancel_damage()` in this class already calls `cleanup_codecs()`, which captures the encoder refs and schedules explicit `clean()` in the encode thread. After that, `super().cleanup()` can safely run `init_vars()`.

### `nvenc: prevent use-after-free SEGV in Encoder __dealloc__`
`__dealloc__` now branches on `self.threaded_init`:
- `True`: log a warning and mark `closed=1` (leak GPU resources rather than crash). Callers MUST call `clean()` before dropping the last reference.
- `False`: `clean()` runs `do_clean()` inline (no thread spawn, no UAF), safe.

Also fix the one-shot `_process_encode` path in `xpra/server/encoder/server.py` to call `encoder.clean()` explicitly — it used to rely on `__dealloc__`.

## Reproducer

`tests/scripts/nvenc_dealloc_uaf_repro.py` exercises the bug in isolation:
- Before this PR: 3/3 SEGV
- After this PR: 3/3 clean exits (with the warning firing as a safety net for any caller that forgets `clean()`)

## Known limitations

A residual narrow race remains in `WindowVideoSource.cleanup()`: if the encode thread is mid-`video_encode` when `cancel_damage` fires, and it reaches `check_pipeline()` before observing `_damage_cancelled`, it can assign a fresh encoder to `self._video_encoder` that `init_vars()` then nulls without `clean()`. With this PR the consequence is a leaked NVENC context per occurrence rather than a SEGV — strict improvement over the previous behavior, but not a complete fix.

Attempts to close the race revealed an ordering subtlety worth flagging:

- An `encode_ended` override can clean any encoder still attached when it runs, but only catches assignments that happen AFTER `init_vars()` (and the racing-in-flight encode's local ref drops before that override runs).
- Synchronously draining the encode thread (`call_in_encode_thread(set_event)` + `event.wait()`) in `cleanup()` would close the race for the per-window `remove_window` path, but breaks the client-disconnect path: `ClientConnectionMuxer.close()` iterates `reversed(CC_BASES)`, so `EncodingsConnection.cleanup()` runs first and queues the `None` end-of-queue sentinel before `WindowsConnection.cleanup()` reaches the per-window cleanups. A drain queued after the sentinel never fires; cleanup stalls for the full timeout. (The comment in `xpra/server/source/encoding.py:cleanup()` about "must come AFTER the window mixin" is misleading vs. the actual reversed-cleanup behavior in `factory.py`.)

Fully eliminating the race would require either reworking the encode-thread shutdown sequence so window-source cleanups can drain reliably, or making `_video_encoder` access synchronized between main and encode threads. Both are larger than this PR.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
Sponsored-By: Netflix