### PR TITLE
asyncio: stop the loop at interpreter shutdown via atexit

### DIFF
--- a/tests/unittests/unit/net/aio_thread_test.py
+++ b/tests/unittests/unit/net/aio_thread_test.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+# This file is part of Xpra.
+# Copyright (C) 2026 Netflix, Inc.
+# Xpra is released under the terms of the GNU GPL v2, or, at your option, any
+# later version. See the file COPYING for details.
+
+# ABOUTME: Tests for ThreadedAsyncioLoop.stop() — verifies the loop is stopped
+# ABOUTME: and the daemon thread is joined, which is what prevents the uvloop
+# ABOUTME: callback vs Py_FinalizeEx race that crashes in PyGILState_Ensure
+# ABOUTME: -> new_threadstate(NULL).
+
+import unittest
+
+from xpra.net.aio.thread import ThreadedAsyncioLoop
+
+
+class TestThreadedAsyncioLoopStop(unittest.TestCase):
+
+    def test_stop_terminates_loop_and_joins_thread(self):
+        tl = ThreadedAsyncioLoop()
+        thread = tl._thread
+        self.assertIsNotNone(thread)
+        self.assertTrue(thread.is_alive())
+        loop = tl.loop
+        self.assertIsNotNone(loop)
+        # We don't assert loop.is_running() here: wait_for_loop() only
+        # waits for self.loop to be assigned, not for run_forever() to
+        # start. Under scheduler pressure that assertion would flake.
+
+        tl.stop()
+
+        self.assertFalse(thread.is_alive(), "asyncio thread did not exit")
+        # run_forever() returns, then loop.close() runs at the end of
+        # the thread; by the time stop() returns from thread.join() the
+        # loop should be closed.
+        self.assertTrue(loop.is_closed(), "loop was not closed on shutdown")
+
+    def test_stop_is_idempotent(self):
+        tl = ThreadedAsyncioLoop()
+        tl.stop()
+        tl.stop()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/xpra/net/aio/thread.py
+++ b/xpra/net/aio/thread.py
@@ -3,10 +3,11 @@
 # Xpra is released under the terms of the GNU GPL v2, or, at your option, any
 # later version. See the file COPYING for details.
 
+import atexit
 import time
 import asyncio
 from typing import Any
-from threading import Lock
+from threading import Lock, Thread
 from collections.abc import Awaitable, Callable
 
 from queue import SimpleQueue
@@ -73,8 +74,57 @@ class ThreadedAsyncioLoop:
 
     def __init__(self):
         self.loop: asyncio.AbstractEventLoop | None = None
-        start_thread(self.run_forever, "asyncio-thread", True)
+        self._thread: Thread | None = start_thread(self.run_forever, "asyncio-thread", True)
         self.wait_for_loop()
+        # Stop the loop at interpreter shutdown so the daemon asyncio
+        # thread is gone before Py_FinalizeEx reaches _PyGILState_Fini.
+        # Without this, libuv can dispatch a callback into uvloop after
+        # autoInterpreterState has been zeroed, crashing in
+        # PyGILState_Ensure -> new_threadstate(NULL).
+        atexit.register(self.stop)
+
+    def stop(self, timeout: float = 1.0) -> None:
+        """Stop the loop and wait briefly for the daemon thread to exit.
+
+        Idempotent: registered as an atexit handler at construction and
+        safe to call again explicitly.
+
+        Guards on loop.is_closed() rather than loop.is_running() because
+        a freshly-constructed loop has is_running() == False until
+        run_forever() actually enters its main loop; if stop() were
+        called in that window with the is_running guard, we'd drop the
+        stop request and the thread would survive into finalization.
+        """
+        loop = self.loop
+        if loop is None:
+            log("stop(): loop=None, nothing to do")
+            atexit.unregister(self.stop)
+            return
+        if loop.is_closed():
+            log("stop(): loop already closed, nothing to do")
+            atexit.unregister(self.stop)
+            return
+        log("stop(): scheduling loop.stop on %s", loop)
+        try:
+            loop.call_soon_threadsafe(loop.stop)
+        except RuntimeError as e:
+            # Loop closed concurrently between the guard and the call.
+            log("stop(): call_soon_threadsafe failed: %s", e)
+            atexit.unregister(self.stop)
+            return
+        thread = self._thread
+        if thread is None or not thread.is_alive():
+            log("stop(): no live thread to join")
+            atexit.unregister(self.stop)
+            return
+        log("stop(): joining asyncio thread (timeout=%ss)", timeout)
+        thread.join(timeout=timeout)
+        if thread.is_alive():
+            log.warn("asyncio thread did not exit within %ss;"
+                     " daemon may race interpreter finalization", timeout)
+        else:
+            log("stop(): asyncio thread exited")
+            atexit.unregister(self.stop)
 
     def run_forever(self) -> None:
         if UVLOOP:


### PR DESCRIPTION
## Background

`ThreadedAsyncioLoop` in `xpra/net/aio/thread.py` runs uvloop's
`run_forever()` on a daemon thread with no shutdown coordination —
no `stop()`, no `atexit`, no caller-side teardown. The
`loop.close()` line after `run_forever()` is unreachable in normal
operation.

The class dates to `072a553e38` (2022-11-06, "#3376 split directory
listing, simplify calling async code"), which introduced the
original `xpra/net/quic/asyncio_thread.py`. It has since been
moved twice (`beab487c7c` to `xpra/net/asyncio/`, then
`7d662ac562` to `xpra/net/aio/` to avoid the stdlib shadow) but the
daemon-thread-no-shutdown design has been unchanged across all
revisions.

## Symptom

During Python interpreter teardown, `_PyGILState_Fini()` zeroes
`gilstate->autoInterpreterState`. If the daemon asyncio thread is
still parked in `uv_run` with a pending libuv callback, the callback
fires, uvloop's C wrapper calls `PyGILState_Ensure()`, and
`new_threadstate(NULL)` segfaults at `Python/pystate.c:1388`.

QUIC-only in practice because aioquic's
`loop.create_datagram_endpoint` is the only path that brings uvloop
into xpra. TCP and WebSocket use xpra's own threaded socket handlers
and never touch uvloop.

Observed twice in production within a week from ordinary
`systemctl restart` cycles with a QUIC client connected:

- SEGV stack: `new_threadstate(interp=0x0)` at `Python/pystate.c:1388`,
  called from `PyGILState_Ensure` (`pystate.c:2218`), called from
  uvloop's C UDP datagram callback inside `uv_run`.
- Same root cause caught later in finalization: uvloop delivered a
  datagram to `XpraWebSocketHandler.http_event_received`'s `log.info`
  call after stdio had been closed, raising
  `ValueError: I/O operation on closed file`.

## Fix

Add `ThreadedAsyncioLoop.stop()` that schedules `loop.stop()` via
`call_soon_threadsafe` and joins the daemon thread with a 1s
timeout. Register it via `atexit` at singleton creation. atexit
fires before `_PyGILState_Fini`, so on the successful-stop path the
daemon thread is gone before the finalization race window opens.

If `stop()` times out at 1s (pathological case where the asyncio
thread is blocked in a long callback), `stop()` logs a warning and
returns; the residual race remains possible in that window but
`daemon=True` keeps process exit from deadlocking. The successful
path is what closes the SEGV.

`stop()` unregisters its own atexit hook on success so re-stops are
idempotent and the bound-method reference does not retain the loop
instance forever.

`stop()` guards on `loop.is_closed()` rather than `loop.is_running()`
because a freshly-constructed loop has `is_running() == False` until
`run_forever()` actually enters its main loop; the `is_running`
guard would drop a stop request fired in that startup window.

Sponsored-By: Netflix