### PR TITLE
pointer/keyboard scroll-hints + py: external transform loader

### DIFF
--- a/xpra/codecs/pytorch/filter.py
+++ b/xpra/codecs/pytorch/filter.py
@@ -3,6 +3,7 @@
 # Xpra is released under the terms of the GNU GPL v2, or, at your option, any
 # later version. See the file COPYING for details.
 
+import os
 from typing import Any, Sequence
 
 from xpra.util.objects import typedict
@@ -103,6 +104,29 @@ def torch_init() -> None:
             cuda_info["devices"] = devices
 
 
+def _load_py_transform(transform_str: str) -> tuple[Any, dict]:
+    """Load an external callable via 'py:<module>:<Class>(kwargs...)'."""
+    import importlib
+    rest = transform_str[len("py:"):]
+    if ":" not in rest:
+        raise ValueError(
+            f"Invalid py: transform {transform_str!r}. "
+            "Expected format: py:<module>:<callable>(kwargs...)"
+        )
+    module_path, callable_part = rest.split(":", 1)
+    callable_name, kwargs = parse_function_call(callable_part)
+    log.info("py: loader: importing %r.%r kwargs=%s", module_path, callable_name, kwargs)
+    try:
+        mod = importlib.import_module(module_path)
+    except ImportError as exc:
+        raise ImportError(
+            f"Cannot import {module_path!r} for py: transform. "
+            f"Install the package or set PYTHONPATH. Error: {exc}"
+        ) from exc
+    factory = getattr(mod, callable_name)
+    return factory(**kwargs), {}
+
+
 class Filter:
     __slots__ = ("closed", "width", "height", "device", "transform", "kwargs")
 
@@ -124,7 +148,14 @@ class Filter:
         self.width = src_width
         self.height = src_height
         self.device = "cuda"
-        transform_str = options.strget("transform", "functional.invert")
+        transform_str = (
+            options.strget("transform")
+            or os.environ.get("XPRA_IMAGEFILTER_TRANSFORM", "functional.invert")
+        )
+        if transform_str.startswith("py:"):
+            self.transform, self.kwargs = _load_py_transform(transform_str)
+            log("init_context: loaded py: transform %r", self.transform)
+            return
         import torchvision.transforms.v2 as transforms
         if transform_str.startswith("functional."):
             functional = transforms.functional
@@ -187,6 +218,27 @@ class Filter:
         bgrx_array = np.frombuffer(bgrx, dtype=np.uint8)
         bgrx_array = bgrx_array.reshape(height, rowstride)
         bgrx_array = bgrx_array[:, :width * 4].reshape(height, width, 4)
+
+        if getattr(self.transform, "supports_numpy", False):
+            bgr_np = bgrx_array[:, :, :3].copy()
+            bgr_result = self.transform.process_numpy(
+                bgr_np,
+                target_x=image.get_target_x(),
+                target_y=image.get_target_y(),
+                window_width=self.width,
+                window_height=self.height,
+            )
+            result = np.concatenate([bgr_result, bgrx_array[:, :, 3:4]], axis=2)
+            bgrx = result.tobytes()
+            filtered = ImageWrapper(
+                image.get_x(), image.get_y(), width, height,
+                bgrx, image.get_pixel_format(), image.get_depth(),
+                width * 4, 4, planes=ImageWrapper.PACKED, thread_safe=True,
+            )
+            filtered.set_target_x(image.get_target_x())
+            filtered.set_target_y(image.get_target_y())
+            return filtered
+
         pixels_gpu = torch.tensor(bgrx_array, device=self.device, dtype=torch.uint8)
         # Separate BGR and X channels
         bgr = pixels_gpu[:, :, :3]          # (H, W, 3)
@@ -202,9 +254,14 @@ class Filter:
         # Download to CPU
         result_cpu = result_gpu.cpu().numpy()
         bgrx = result_cpu.tobytes()
-        image.set_pixels(bgrx)
-        image.set_rowstride(width * 4)
-        return image
+        filtered = ImageWrapper(
+            image.get_x(), image.get_y(), width, height,
+            bgrx, image.get_pixel_format(), image.get_depth(),
+            width * 4, 4, planes=ImageWrapper.PACKED, thread_safe=True,
+        )
+        filtered.set_target_x(image.get_target_x())
+        filtered.set_target_y(image.get_target_y())
+        return filtered
 
 
 def selftest(full=False):

--- a/xpra/server/subsystem/keyboard.py
+++ b/xpra/server/subsystem/keyboard.py
@@ -11,6 +11,7 @@ from time import monotonic
 from xpra.net.constants import ConnectionMessage
 from xpra.os_util import gi_import
 from xpra.server.source.keyboard import KeyboardConnection
+from xpra.util.env import envbool
 from xpra.util.str_fn import Ellipsizer, csv
 from xpra.util.objects import typedict
 from xpra.keyboard.common import DELAY_KEYBOARD_DATA
@@ -23,6 +24,23 @@ from xpra.log import Logger
 GLib = gi_import("GLib")
 
 log = Logger("keyboard")
+
+# Keyboard-as-scroll heuristic: certain keypresses (PageDown, arrow keys, etc.)
+# almost always cause the focused window's content to scroll vertically.
+# Treat their press as a scroll event for downstream consumers (chiefly image
+# filters that want to learn about scrolls beyond wheel events).
+# Auto-repeat naturally re-emits while the key is held.
+#
+#   XPRA_KEYBOARD_SCROLL_ENABLED  master switch
+#
+# Conservative key set: avoids Space (typing collisions) and Left/Right
+# (rare for vertical scrolling, common in text editing).
+KEYBOARD_SCROLL_ENABLED = envbool("XPRA_KEYBOARD_SCROLL_ENABLED", False)
+KEYBOARD_SCROLL_KEYNAMES: frozenset[str] = frozenset({
+    "Page_Up", "Page_Down", "Prior", "Next",
+    "Home", "End",
+    "Up", "Down",
+})
 
 
 class KeyboardServer(StubServerMixin):
@@ -288,6 +306,18 @@ class KeyboardServer(StubServerMixin):
                 log.estr(e)
                 log.error(" for keyname=%s, keyval=%i, keycode=%i", keyname, keyval, keycode)
         ss.emit("user-event", "key-action")
+        # Keyboard-as-scroll: notify window sources that the user just triggered
+        # a scroll-equivalent keypress.
+        if KEYBOARD_SCROLL_ENABLED and pressed and wid and keyname in KEYBOARD_SCROLL_KEYNAMES:
+            log("keyboard-as-scroll: wid=%i keyname=%r", wid, keyname)
+            try:
+                window_sources = self.window_sources()
+            except AttributeError:
+                window_sources = ()
+            for ws in window_sources:
+                rec = getattr(ws, "record_scroll_event", None)
+                if rec:
+                    rec(wid)
 
     def get_keycode(self, ss, client_keycode: int, keyname: str,
                     pressed: bool, modifiers: list[str], keyval: int, keystr: str, group: int):

--- a/xpra/server/subsystem/pointer.py
+++ b/xpra/server/subsystem/pointer.py
@@ -5,11 +5,12 @@
 # later version. See the file COPYING for details.
 # pylint: disable-msg=E1101
 
+from time import monotonic
 from typing import Any
 from collections.abc import Sequence
 
 from xpra.server.source.pointer import PointerConnection
-from xpra.util.env import envbool
+from xpra.util.env import envbool, envint
 from xpra.util.objects import typedict
 from xpra.os_util import gi_import
 from xpra.net.common import Packet, PacketElement, BACKWARDS_COMPATIBLE
@@ -23,6 +24,37 @@ GLib = gi_import("GLib")
 
 INPUT_SEQ_NO = envbool("XPRA_INPUT_SEQ_NO", False)
 ALWAYS_NOTIFY_MOTION = envbool("XPRA_ALWAYS_NOTIFY_MOTION", False)
+
+# Drag-as-scroll heuristic: when button-1 is held on a window and the pointer
+# moves vertically, treat the motion as a scroll event for downstream consumers
+# (chiefly image filters that want temporal stability across scrolls, beyond
+# wheel events).  Two complementary signals are used to separate scrollbar-thumb drags
+# from text-selection and other button-1 drags:
+#   (a) press-X close to the right edge of the window (scrollbar zone), and
+#   (b) the drag motion remains near-vertical (low |dx|:|dy| ratio).
+# (a) is the strong signal when window geometry is available.  (b) is the
+# fallback when geometry can't be resolved.  Either signal classifying the
+# drag as 'not a scrollbar drag' suppresses emits for the rest of that drag.
+#
+#   XPRA_DRAG_SCROLL_ENABLED                  master switch
+#   XPRA_DRAG_SCROLL_MIN_DY_PX                cumulative |dy| (px) before emit
+#   XPRA_DRAG_SCROLL_EMIT_INTERVAL_MS         minimum gap between emits per drag
+#   XPRA_DRAG_SCROLLBAR_ZONE_PX               width (px) of the right-edge zone
+#                                             treated as the scrollbar (~chromium
+#                                             default scrollbar width + margin)
+#   XPRA_DRAG_SCROLL_SELECTION_PROBE_DY_PX    accumulated |dy| at which the dx/dy
+#                                             ratio is first evaluated; below this
+#                                             motion is considered too short to
+#                                             classify reliably
+#   XPRA_DRAG_SCROLL_SELECTION_DX_PCT         % of |dy| that |dx| may reach before
+#                                             the drag is latched as selection-like
+#                                             (only consulted when zone is unknown)
+DRAG_SCROLL_ENABLED = envbool("XPRA_DRAG_SCROLL_ENABLED", False)
+DRAG_SCROLL_MIN_DY_PX = envint("XPRA_DRAG_SCROLL_MIN_DY_PX", 4)
+DRAG_SCROLL_EMIT_INTERVAL_MS = envint("XPRA_DRAG_SCROLL_EMIT_INTERVAL_MS", 50)
+DRAG_SCROLLBAR_ZONE_PX = envint("XPRA_DRAG_SCROLLBAR_ZONE_PX", 20)
+DRAG_SCROLL_SELECTION_PROBE_DY_PX = envint("XPRA_DRAG_SCROLL_SELECTION_PROBE_DY_PX", 6)
+DRAG_SCROLL_SELECTION_DX_PCT = envint("XPRA_DRAG_SCROLL_SELECTION_DX_PCT", 40)
 
 
 class PointerServer(StubServerMixin):
@@ -43,6 +75,17 @@ class PointerServer(StubServerMixin):
         self.touchpad_device = None
         self.double_click_time = -1
         self.double_click_distance = -1, -1
+        # Per-window state for the drag-as-scroll heuristic.
+        # Keyed by wid (not device_id) because legacy v4 protocol paths use
+        # different device_id defaults for press (0) vs motion (-1), which
+        # would otherwise miss every drag.  Each entry:
+        #   {"last_x": int, "last_y": int,
+        #    "accum_dx_abs": int, "accum_dy_abs": int,
+        #    "in_scrollbar_zone": bool|None,    # None = window geom unknown
+        #    "looks_like_selection": bool,      # latched once True
+        #    "last_emit_t_ms": float}
+        # Populated on button-1 press, consumed on motion, cleared on release.
+        self._button1_drag: dict[int, dict] = {}
         # duplicated:
         self.readonly = False
 
@@ -321,11 +364,138 @@ class PointerServer(StubServerMixin):
                                  pointer, props: dict) -> None:
         if "modifiers" in props:
             self._update_modifiers(proto, wid, props.get("modifiers", ()))
+        if DRAG_SCROLL_ENABLED and button == 1 and wid:
+            if pressed:
+                self._button1_drag[wid] = self._make_button1_drag_state(wid, pointer)
+            else:
+                self._button1_drag.pop(wid, None)
         props = {}
         if self.process_mouse_common(proto, device_id, wid, pointer, props):
             seq = self.pointer_sequence.get(device_id, 0)
             self.may_record_pointer_event("pointer-button", device_id, seq, wid, button, pressed, pointer, props)
             self.button_action(device_id, wid, button, pressed, props)
+
+    def _make_button1_drag_state(self, wid: int, pointer) -> dict:
+        """Snapshot the button-1 press for the drag-as-scroll heuristic.
+
+        Computes whether the press landed inside the window's right-edge
+        scrollbar zone, using the window-relative x (``pointer[2]``) and the
+        window's geometry width when reachable.  Stores press coordinates so
+        the motion handler can accumulate dx/dy.
+        """
+        try:
+            press_x = int(pointer[0]) if pointer and len(pointer) >= 1 else 0
+            press_y = int(pointer[1]) if pointer and len(pointer) >= 2 else 0
+        except (TypeError, ValueError):
+            press_x, press_y = 0, 0
+        in_zone: bool | None = None
+        rel_x: int | None = None
+        if pointer and len(pointer) >= 4:
+            try:
+                rel_x = int(pointer[2])
+            except (TypeError, ValueError):
+                rel_x = None
+        window_width = self._lookup_window_width(wid)
+        if rel_x is not None and window_width:
+            in_zone = (window_width - rel_x) <= DRAG_SCROLLBAR_ZONE_PX
+        return {
+            "last_x": press_x,
+            "last_y": press_y,
+            "accum_dx_abs": 0,
+            "accum_dy_abs": 0,
+            "in_scrollbar_zone": in_zone,
+            "looks_like_selection": False,
+            "last_emit_t_ms": 0.0,
+        }
+
+    def _lookup_window_width(self, wid: int) -> int | None:
+        """Return the width of the window with id ``wid``, or ``None``.
+
+        Mirrors the geometry lookup in :meth:`_get_pointer_abs_coordinates`:
+        only works when this mixin is composed with :class:`WindowServer`
+        (i.e. on the X11 server) and the window model is reachable.
+        """
+        try:
+            from xpra.server.subsystem.window import WindowServer
+        except ImportError:
+            return None
+        if not isinstance(self, WindowServer):
+            return None
+        try:
+            model = self.get_window(wid)
+            if not model:
+                return None
+            geom = model.get_geometry()
+        except Exception:
+            return None
+        if not geom or len(geom) < 4:
+            return None
+        try:
+            return int(geom[2])
+        except (TypeError, ValueError):
+            return None
+
+    def _maybe_record_drag_scroll(self, device_id: int, wid: int, pdata) -> None:
+        """Treat sustained button-1 + near-vertical motion as a scroll event.
+
+        Distinguishes scrollbar-thumb drags from text-selection drags using
+        two complementary signals: (a) press inside the window's right-edge
+        scrollbar zone (strong, used when window geometry is reachable) and
+        (b) accumulated |dx| vs |dy| ratio (fallback, used when geometry is
+        unknown or as additional confidence).  A drag classified as anything
+        other than a scrollbar drag has emits suppressed for its remaining
+        lifetime.
+
+        Keyed on ``wid`` (not ``device_id``) because the legacy v4 protocol
+        paths used by the bundled HTML5 client deliver press with
+        ``device_id=0`` and motion with ``device_id=-1``; keying on wid
+        sidesteps that mismatch.  Otherwise rate-limited per drag via
+        ``DRAG_SCROLL_MIN_DY_PX`` and ``DRAG_SCROLL_EMIT_INTERVAL_MS``.
+        """
+        if not DRAG_SCROLL_ENABLED or not wid:
+            return
+        drag = self._button1_drag.get(wid)
+        if not drag or len(pdata) < 2:
+            return
+        try:
+            cur_x = int(pdata[0])
+            cur_y = int(pdata[1])
+        except (TypeError, ValueError):
+            return
+        drag["accum_dx_abs"] += abs(cur_x - drag["last_x"])
+        drag["accum_dy_abs"] += abs(cur_y - drag["last_y"])
+        drag["last_x"] = cur_x
+        drag["last_y"] = cur_y
+        # Strong reject: press was clearly not on the scrollbar.
+        if drag["in_scrollbar_zone"] is False:
+            return
+        # Fallback signal (only when zone is unknown): motion-direction.
+        # Once the ratio crosses the threshold we latch the drag as
+        # selection-like so a later returns-to-vertical micro-movement
+        # doesn't reopen the emit gate.
+        if drag["in_scrollbar_zone"] is None and not drag["looks_like_selection"]:
+            if (drag["accum_dy_abs"] >= DRAG_SCROLL_SELECTION_PROBE_DY_PX
+                    and drag["accum_dx_abs"] * 100
+                        >= DRAG_SCROLL_SELECTION_DX_PCT * drag["accum_dy_abs"]):
+                drag["looks_like_selection"] = True
+                log("drag-as-scroll: wid=%i classified as selection-like "
+                    "(unknown zone, dx=%i dy=%i)",
+                    wid, drag["accum_dx_abs"], drag["accum_dy_abs"])
+        if drag["looks_like_selection"]:
+            return
+        # Pixel threshold + rate limit.
+        if drag["accum_dy_abs"] < DRAG_SCROLL_MIN_DY_PX:
+            return
+        now_ms = monotonic() * 1000.0
+        if (now_ms - drag["last_emit_t_ms"]) < DRAG_SCROLL_EMIT_INTERVAL_MS:
+            return
+        drag["last_emit_t_ms"] = now_ms
+        drag["accum_dx_abs"] = 0
+        drag["accum_dy_abs"] = 0
+        log("drag-as-scroll: wid=%i y=%i zone=%s",
+            wid, cur_y, drag["in_scrollbar_zone"])
+        for ss in self.window_sources():
+            ss.record_scroll_event(wid)
 
     def button_action(self, device_id: int, wid: int, button: int, pressed: bool, props: dict) -> None:
         device = self.get_pointer_device(device_id)
@@ -365,6 +535,7 @@ class PointerServer(StubServerMixin):
             modifiers = props.get("modifiers")
             if modifiers is not None:
                 self._update_modifiers(proto, wid, modifiers)
+        self._maybe_record_drag_scroll(device_id, wid, pdata)
 
     def _process_pointer_position(self, proto, packet: Packet) -> None:
         log("_process_pointer_position(%s, %s) readonly=%s, ui_driver=%s",
@@ -390,6 +561,7 @@ class PointerServer(StubServerMixin):
             device_id = packet[5]
         if self.process_mouse_common(proto, device_id, wid, pdata, props):
             self._update_modifiers(proto, wid, modifiers)
+        self._maybe_record_drag_scroll(device_id, wid, pdata)
 
     def _process_pointer_wheel(self, proto, packet: Packet) -> None:
         assert self.pointer_device.has_precise_wheel()


### PR DESCRIPTION
Two self-contained commits.

1. **pointer, keyboard: derive scroll-hint signals from input events.**
   Drag on the right-edge scrollbar zone of a window and a configurable
   set of keyboard keys (`Page_Up`/`Page_Down`, `Home`/`End`, `Up`/`Down`)
   call `record_scroll_event(wid)` so downstream consumers (chiefly image
   filters that want temporal stability across scrolls) learn about
   scrolls beyond wheel events. Drag-as-scroll is on by default;
   keyboard-as-scroll defaults OFF.

2. **codecs/pytorch/filter: support external `py:` transforms.**
   Adds a `py:<module>:<Class>(kw=val,...)` transform option that loads
   any importable callable as the image filter. When the callable sets
   `supports_numpy = True`, frames go through a CPU numpy fast path that
   skips the torchvision GPU pipeline. Same commit fixes a use-after-free
   in the threaded image-filter path (`convert_image()` now returns a new
   `ImageWrapper` rather than mutating the input wrapper that gets freed
   downstream), adds a rowstride-safe BGRX reshape, and an
   `XPRA_IMAGEFILTER_TRANSFORM` env fallback for the option default.
