### PR TITLE
opengl: expose full GL_VERSION string in client.opengl info

### DIFF
--- a/xpra/opengl/check.py
+++ b/xpra/opengl/check.py
@@ -430,6 +430,12 @@ def do_check_PyOpenGL_support(force_enable) -> dict[str, Any]:
         return props
     # '4.6.0 NVIDIA 440.59' -> ['4', '6', '0 NVIDIA...']
     log("GL_VERSION=%s", gl_version_str)
+    # The full string carries driver name + driver version (e.g. "Mesa
+    # 26.2.0-devel (git-...)" or "NVIDIA 440.59"), which is often what
+    # you actually need when diagnosing a driver-specific issue. The
+    # parsed (major, minor) tuple alone collapses every driver to the
+    # same value. Store both.
+    props["version"] = gl_version_str.strip()
     vparts = gl_version_str.split(" ", 1)[0].split(".")
     try:
         gl_major = int(vparts[0])


### PR DESCRIPTION
## Summary

Currently `gl_check_backend` parses `GL_VERSION` and stores only the parsed `(major, minor)` tuple under `props["opengl"]`, discarding the driver-name suffix. The raw string carries the driver name + driver version (e.g. `"4.6 (Compatibility Profile) Mesa 26.2.0-devel (git-...)"` or `"4.6.0 NVIDIA 470.86"`) which is typically the load-bearing piece of information when diagnosing a driver-specific bug.

This PR stores the trimmed full string under `props["version"]` so it shows up as `client.opengl.version` via `xpra info`. The existing `log("GL_VERSION=%s", ...)` debug line is unchanged.

## Why

While debugging a Mesa-`d3d12`-specific driver bug (see #4889 / https://gitlab.freedesktop.org/mesa/mesa/-/issues/15513), the renderer string (`client.opengl.renderer`) was queryable via `xpra info` but the driver-version string that distinguishes the broken Mesa `26.2.0-devel` from a working `26.1.1` build wasn't — it was only at debug log level. Promoting it to props closes a real diagnostic gap. Originally bundled with #4889 but split out per reviewer request.

Sponsored-By: Netflix