### PR TITLE
launcher: start the protocol so the client reads the server's replies

### DIFF
--- a/xpra/client/gtk3/launcher.py
+++ b/xpra/client/gtk3/launcher.py
@@ -896,7 +896,12 @@ class ApplicationWindow:
         log("do_start_XpraClient(%s, %s) client=%s", conn, display_desc, self.client)
         self.client.encoding = self.config.encoding
         self.client.display_desc = display_desc
-        self.client.make_protocol(conn)
+        protocol = self.client.make_protocol(conn)
+        # make_protocol() does not start the protocol: the network read thread
+        # is only started by protocol.start() (as the command-line client does).
+        # Without this the client sends its hello but never reads the server's
+        # reply, so the connection times out with 0 packets received.
+        protocol.start()
         self.set_info_text("Network connection established")
         log("start_XpraClient() client initialized")
 


### PR DESCRIPTION
The GTK launcher's built-in connection path (`do_start_xpra_client`) calls `make_protocol()` but never calls `protocol.start()`.

`make_protocol()` builds the `SocketProtocol` and schedules `send_hello()`, but the network read thread is only started by `protocol.start()` — which the command-line client does explicitly (`xpra/scripts/main.py`) while the launcher does not.

As a result, a client started from the GTK launcher sends its hello but never reads anything back: the connection reports "network connection established" and then times out with "0 packets received" on every transport (tcp, ssl, quic).

This regressed in 25d6e80b05c, which split `make_protocol()` out of `setup_connection()` and moved the `start()` responsibility to the callers; the command-line callers were updated but the launcher was missed.

The fix calls `protocol.start()` after `make_protocol()`, matching the command-line client. Verified on Windows (GTK launcher, built-in connect): with this change the launcher connects over both tcp and quic; without it the client hangs after "network connection established".

Sponsored-By: Netflix
