### PR TITLE
fix(audio): repair PulseAudio device enumeration for microphone forwarding

### DIFF
--- a/xpra/audio/pulseaudio/pactl_impl.py
+++ b/xpra/audio/pulseaudio/pactl_impl.py
@@ -174,6 +174,13 @@ def do_get_pa_device_options(pactl_list_output, monitors=False, input_or_output=
                 return False
         return True
 
+    # a caller asking for non-monitor *output* devices wants a real sink
+    # (this is what `pulsesink device=` needs); everything else wants a source.
+    # Without this, sinks are never enumerated and callers such as
+    # get_pulse_sink_defaults() fall back to a monitor name, which pulsesink
+    # cannot negotiate ("not-negotiated (-4)") - breaking microphone forwarding.
+    section_prefix = "Sink #" if (monitors is False and input_or_output is False) else "Source #"
+
     name: str | None = None
     device_class: str | None = None
     monitor_of_sink: str | None = None
@@ -191,7 +198,7 @@ def do_get_pa_device_options(pactl_list_output, monitors=False, input_or_output=
             device_class = None
             monitor_of_sink = None
             device_description = None
-            in_source_section = line.startswith("Source #")
+            in_source_section = line.startswith(section_prefix)
         line = line.strip()
         if line.startswith("Name: "):
             name = line.removeprefix("Name: ")

--- a/xpra/audio/pulseaudio/pactl_impl.py
+++ b/xpra/audio/pulseaudio/pactl_impl.py
@@ -203,7 +203,11 @@ def do_get_pa_device_options(pactl_list_output, monitors=False, input_or_output=
         if line.startswith("Name: "):
             name = line.removeprefix("Name: ")
         if line.startswith("device.class = "):
-            device_class = line.removeprefix("device-class = ")
+            # the prefix removed here must match the one tested above ("device.class",
+            # not "device-class"), otherwise device_class keeps the whole line and no
+            # device is ever recognised as a monitor - which makes monitor lookups
+            # return nothing and callers fall back to the default source.
+            device_class = line.removeprefix("device.class = ")
         if line.startswith("Monitor of Sink: "):
             monitor_of_sink = line.removeprefix("Monitor of Sink: ")
         if line.startswith("device.description = "):


### PR DESCRIPTION
Fixes #4983.

Two independent regressions in `do_get_pa_device_options()` break microphone forwarding on
servers with no real audio hardware, and make speaker forwarding echo the client's own microphone
back to it. One commit each.

## 1. Only enumerate sinks when a real sink is requested

`do_get_pa_device_options()` only scanned `Source #` sections, so `get_pulse_sink_defaults()` —
whose purpose is to find a sink for `pulsesink device=` — could never return one and fell back to
a monitor name. A monitor is a source and cannot be a `pulsesink` target, so every microphone
playback pipeline died on preroll and was respawned in a tight loop:

```
audio playback using pulseaudio device:
audio playback  '"Monitor of Xpra-Microphone"'
audio playback Gstreamer pipeline error: Internal data stream error.
audio playback  /GstPipeline:pipeline0/GstAppSrc:src:
audio playback  streaming stopped, reason not-negotiated (-4)
⚠️  stopping audio input because of an error
```

Reproducible without xpra:

```bash
gst-launch-1.0 audiotestsrc num-buffers=100 ! audioconvert ! pulsesink device=Xpra-Microphone.monitor
# ERROR: Sink not negotiated before eos event.   <- what xpra does
gst-launch-1.0 audiotestsrc num-buffers=100 ! audioconvert ! pulsesink device=Xpra-Microphone
# clean
```

`XPRA_PULSE_SINK_DEVICE_NAME` could not work around it, because `filter_name()` only filters the
already-enumerated (source-only) list — the named sink was never a candidate.

The fix scans `Sink #` sections when the caller asks for non-monitor *output* devices. That
condition selects exactly one caller, `get_pulse_sink_defaults()`. The others are unaffected:
`get_pulse_source_defaults(want_monitor_device=True)` passes `monitors=True`, and with
`want_monitor_device=False` it passes `input_or_output=True`.

Regressed in b762cc59, which added `in_source_section` to stop sinks being returned as *capture*
devices — correct in itself, but it made the function source-only for every caller including the
one that needs a sink. Its own commit message notes the caveat that now applies to the new
breakage: *"This matters when no real audio hardware is present; masked by USE_DEFAULT_DEVICE on
typical desktop systems."*

## 2. Match the `device.class` prefix so monitors are detected

```python
if line.startswith("device.class = "):
    device_class = line.removeprefix("device-class = ")
```

The prefix tested and the prefix removed differ, so `removeprefix()` is a no-op, `device_class`
keeps the whole line, and `device_class == '"monitor"'` is never true — no device is ever
classified as a monitor. Monitor lookups return `{}`:

```
🔴 audio forwarding is disabled
   could not detect any Pulseaudio output monitor devices
```

`get_pulse_device()` then returns `""`, and GStreamer falls back to the PulseAudio default source,
which the server sets to `Xpra-Mic-Source` — so speaker forwarding captures the client's own
microphone.

Regressed in 1b6389aa. The original `line[len("device-class = "):]` was accidentally correct:
`"device-class = "` and `"device.class = "` are both 15 characters, so slicing by length worked
despite the wrong string. `removeprefix()` requires an exact match.

## Verification

Both fixes were applied to a live xpra 6.5.1 server (Ubuntu 22.04, GStreamer 1.20.3, headless —
no `/proc/asound`, stock `Xpra-Speaker` / `Xpra-Microphone` null sinks + `Xpra-Mic-Source` remap).
Microphone forwarding from a Windows client now works, and the echo is gone. Picking up the change
required restarting both server and client.

Running this branch's `do_get_pa_device_options()` against that host's `pactl list` output:

| lookup | caller | before | after |
| --- | --- | --- | --- |
| `(monitors=False, input_or_output=False)` | `get_pulse_sink_defaults()` | `['Xpra-Mic-Source', 'Xpra-Microphone.monitor', 'Xpra-Speaker.monitor']` | `['Xpra-Microphone', 'Xpra-Speaker']` |
| `(monitors=True, input_or_output=False)` | `get_pulse_source_defaults(want_monitor_device=True)` | `[]` | `['Xpra-Microphone.monitor', 'Xpra-Speaker.monitor']` |
| `(monitors=False, input_or_output=True)` | `get_pulse_source_defaults(want_monitor_device=False)` | `['Xpra-Mic-Source', 'Xpra-Microphone.monitor', 'Xpra-Speaker.monitor']` | `['Xpra-Mic-Source']` |

The existing `XPRA_PULSE_SINK_DEVICE_NAME=Xpra-Microphone` and
`XPRA_PULSE_SOURCE_DEVICE_NAME=Xpra-Speaker` defaults then narrow each set to exactly the right
device.
