### PR TITLE
Fix Wayland frame callbacks for empty-damage commits

### DIFF
--- a/tests/unittests/unit/wayland/window_test.py
+++ b/tests/unittests/unit/wayland/window_test.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+# This file is part of Xpra.
+# Copyright (C) 2026 Antoine Martin <antoine@xpra.org>
+# Xpra is released under the terms of the GNU GPL v2, or, at your option, any
+# later version. See the file COPYING for details.
+
+import sys
+import unittest
+from types import ModuleType
+from unittest.mock import Mock, patch
+
+
+def load_window_server_class():
+    modules = {}
+    for module_name, class_name in (
+            ("xpra.wayland.server.popup", "Popup"),
+            ("xpra.wayland.server.subsurface", "Subsurface"),
+            ("xpra.wayland.server.surface", "Surface"),
+    ):
+        module = ModuleType(module_name)
+        setattr(module, class_name, type(class_name, (), {}))
+        modules[module_name] = module
+    with patch.dict(sys.modules, modules):
+        from xpra.wayland.server.subsystem.window import WaylandWindowServer
+    return WaylandWindowServer
+
+
+WaylandWindowServer = load_window_server_class()
+
+
+class WaylandWindowServerCommitTest(unittest.TestCase):
+
+    @staticmethod
+    def make_server(window):
+        server = Mock()
+        server.get_window.return_value = window
+        server.get_surface.return_value = Mock()
+        server.subsurface_info = {}
+        server.subsurface_facades = {}
+        server.window_sources.return_value = ()
+        return server
+
+    def test_mapped_empty_damage_acknowledges_after_subsurface_updates(self):
+        window = Mock()
+        server = self.make_server(window)
+        facade = Mock()
+        subsource = Mock()
+        source = Mock()
+        source.subsurface_sources = {2: subsource}
+        server.subsurface_facades[2] = facade
+        server.window_sources.return_value = (source,)
+        subsurface = (2, 3, 4, 5, 6, 10, 12)
+
+        def check_subsurface_updates():
+            surface = server.get_surface.return_value
+            server.track_toplevel.assert_called_once_with(surface)
+            server.update_colourspace.assert_called_once_with(window, surface)
+            server.update_size.assert_called_once_with(window, (100, 80))
+            self.assertEqual(server.subsurface_info[2], (7, 3, 4, 5, 6, 10, 12))
+            facade.update_dimensions.assert_called_once_with(5, 6)
+            subsource.update_geometry.assert_called_once_with(7, 3, 4, 5, 6, 10, 12)
+
+        window.acknowledge_changes.side_effect = check_subsurface_updates
+        WaylandWindowServer.commit(server, 7, True, (100, 80), (), [subsurface])
+
+        window.acknowledge_changes.assert_called_once_with()
+        server.refresh_window_area.assert_not_called()
+
+    def test_mapped_damage_refreshes_without_immediate_acknowledgement(self):
+        window = Mock()
+        server = self.make_server(window)
+        refreshes = []
+        server.refresh_window_area.side_effect = (
+            lambda win, x, y, w, h, options: refreshes.append((win, x, y, w, h, dict(options)))
+        )
+
+        WaylandWindowServer.commit(server, 7, True, (100, 80),
+                                   ((1, 2, 3, 4), (5, 6, 7, 8)), [])
+
+        self.assertEqual(refreshes, [
+            (window, 1, 2, 3, 4, {"damage": True, "more": True}),
+            (window, 5, 6, 7, 8, {"damage": True, "more": False}),
+        ])
+        window.acknowledge_changes.assert_not_called()
+
+    def test_unmapped_empty_damage_is_ignored(self):
+        window = Mock()
+        server = self.make_server(window)
+
+        WaylandWindowServer.commit(server, 7, False, (100, 80), (), [])
+
+        window.acknowledge_changes.assert_not_called()
+        server.refresh_window_area.assert_not_called()
+
+    def test_unknown_window_is_ignored(self):
+        server = self.make_server(None)
+
+        WaylandWindowServer.commit(server, 7, True, (100, 80), (), [])
+
+        server.get_surface.assert_not_called()
+        server.refresh_window_area.assert_not_called()
+
+
+def main():
+    unittest.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/xpra/wayland/server/subsystem/window.py
+++ b/xpra/wayland/server/subsystem/window.py
@@ -255,6 +255,9 @@ class WaylandWindowServer(WindowServer):
                 sub_ws = ss.subsurface_sources.get(sub_wid)
                 if sub_ws:
                     sub_ws.update_geometry(wid, sx, sy, logical_w, logical_h, native_w, native_h)
+        if mapped and not rects:
+            window.acknowledge_changes()
+            return
         options = {"damage": True}
         last = len(rects) - 1
         for i, (x, y, w, h) in enumerate(rects):


### PR DESCRIPTION
## Summary

- Prevent native Wayland seamless clients from stalling visual updates after a mapped commit with an empty damage list, even though pointer and keyboard events continue to arrive. A manual refresh advances one frame because the application is still waiting for its Wayland frame callback.
- Acknowledge mapped empty-damage commits after surface, size, colourspace, and subsurface bookkeeping. With no rectangles, no encoding work is queued, so this direct acknowledgement supplies `frame_done()` and flushes the client.
- Leave unknown windows and unmapped empty commits unchanged. Commits with damage rectangles still use the normal damage/encoding acknowledgement path, without an extra immediate acknowledgement.
- Add deterministic coverage for mapped empty-damage, normal damaged, unmapped empty-damage, unknown-window, and subsurface-ordering behavior. No documentation change is needed for this internal backend correctness fix.
- GitHub searches found no issue or pull request describing the same frame-callback failure. The closest context is [#4877](https://github.com/Xpra-org/xpra/issues/4877), which covers hardware-accelerated Wayland clients and dmabuf rather than empty-damage stalls.

## Test plan

- [x] Focused Wayland window unit tests (4 passed)
- [x] Xpra unit-test runner with native Wayland support (4 passed)
- [x] Cython-enabled server and Wayland build (4 passed)
- [x] Ruff and flake8 checks
- [x] Python compile check
- [x] `git diff --check`
