### PR TITLE
Link Wayland helper extensions against wayland-server

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3771,8 +3771,8 @@ if wayland_server_ENABLED:
         print("generating %r" % header_path)
         subprocess.run(["wayland-scanner", "server-header", xml_path, header_path])
     wlr_args = ["-DWLR_USE_UNSTABLE", "-I./xpra/wayland/server/"]
-    ace("xpra.wayland.server.events", "wlroots-0.19", extra_compile_args=wlr_args)
-    ace("xpra.wayland.server.display", "wlroots-0.19", extra_compile_args=wlr_args)
+    ace("xpra.wayland.server.events", "wlroots-0.19,wayland-server", extra_compile_args=wlr_args)
+    ace("xpra.wayland.server.display", "wlroots-0.19,wayland-server", extra_compile_args=wlr_args)
     ace("xpra.wayland.server.output", "wlroots-0.19,libdrm,wayland-server", extra_compile_args=wlr_args)
     ace("xpra.wayland.server.pointer","wlroots-0.19,wayland-server", extra_compile_args=wlr_args)
     ace("xpra.wayland.server.keyboard","wlroots-0.19,wayland-server", extra_compile_args=wlr_args)

--- a/tests/unittests/unit/wayland/linkage_test.py
+++ b/tests/unittests/unit/wayland/linkage_test.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python3
+# This file is part of Xpra.
+# Copyright (C) 2026 Antoine Martin <antoine@xpra.org>
+# Xpra is released under the terms of the GNU GPL v2, or, at your option, any
+# later version. See the file COPYING for details.
+
+import importlib.util
+import subprocess
+import sys
+import unittest
+
+
+WAYLAND_MODULES = (
+    "xpra.wayland.server.events",
+    "xpra.wayland.server.display",
+)
+
+
+class WaylandLinkageTest(unittest.TestCase):
+
+    def test_isolated_imports(self):
+        available = tuple(module for module in WAYLAND_MODULES if importlib.util.find_spec(module))
+        if not available:
+            self.skipTest("Wayland server modules are not built")
+        self.assertEqual(available, WAYLAND_MODULES)
+        for module in WAYLAND_MODULES:
+            with self.subTest(module=module):
+                proc = subprocess.run(
+                    (sys.executable, "-c", f"import {module}"),
+                    stdout=subprocess.PIPE,
+                    stderr=subprocess.PIPE,
+                    text=True,
+                    check=False,
+                )
+                self.assertEqual(proc.returncode, 0, proc.stderr)
+
+
+def main():
+    unittest.main()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Link the Wayland `events` and `display` helpers directly against
  `wayland-server`, which provides the symbols they call.
- Avoid clean-process import failures for `wl_list_insert`, `wl_list_remove`,
  and `wl_display_flush_clients`; relying on transitive linkage or import order
  is unreliable with `--as-needed` linking.
- Verify each helper import in a separate fresh subprocess so another Wayland
  extension cannot mask a missing direct dependency.

No matching Xpra issue or pull request was found.

## Test plan

- [x] Clean Wayland build, isolated imports, ELF dependency checks, and complete
  Wayland unit-test subset
- [x] Full supported unit-test checklist: 272 successful, 0 failed, 7 requested
  slow-test exclusions
- [x] Ruff, Flake8, and `git diff --check`
- [ ] Additional `CYTHONIZE_MORE=with` build: current upstream stops before the
  tests in `xpra/x11/subsystem/window.py` because `ss` is referenced before
  assignment; this code is outside this change

No documentation or release-note changes are needed for this build-linkage
correction.
