### PR TITLE
Detect libyuv installations without pkg-config metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -536,7 +536,9 @@ nvdec_ENABLED           = False
 nvfbc_ENABLED           = nvidia_ENABLED and not ARM and pkg_config_exists("nvfbc")
 cuda_kernels_ENABLED    = nvidia_ENABLED and (nvenc_ENABLED or nvjpeg_encoder_ENABLED)
 cuda_rebuild_ENABLED    = None if (nvidia_ENABLED and not WIN32) else False
-csc_libyuv_ENABLED      = DEFAULT and pkg_config_exists("libyuv")
+libyuv_pkgconfig        = pkg_config_exists("libyuv")
+libyuv_fallback         = not libyuv_pkgconfig and POSIX and not OSX and has_header_file("libyuv.h")
+csc_libyuv_ENABLED      = DEFAULT and (libyuv_pkgconfig or libyuv_fallback)
 gstreamer_ENABLED       = DEFAULT
 example_ENABLED         = DEFAULT
 win32_tools_ENABLED     = WIN32 and DEFAULT
@@ -3650,7 +3652,12 @@ toggle_packages(jph_ENABLED, "xpra.codecs.jph")
 tace(jph_encoder_ENABLED, "xpra.codecs.jph.encoder,xpra/codecs/jph/jph.cpp", OPENJPH_PKG_CONFIG, language="c++")
 tace(jph_decoder_ENABLED, "xpra.codecs.jph.decoder,xpra/codecs/jph/jph.cpp", OPENJPH_PKG_CONFIG, language="c++")
 toggle_packages(csc_libyuv_ENABLED, "xpra.codecs.libyuv")
-tace(csc_libyuv_ENABLED, "xpra.codecs.libyuv.converter", "libyuv", language="c++")
+if csc_libyuv_ENABLED:
+    if libyuv_fallback:
+        libyuv_kwargs = {"libraries": ("yuv", )}
+    else:
+        libyuv_kwargs = pkgconfig("libyuv")
+    ace("xpra.codecs.libyuv.converter", language="c++", **libyuv_kwargs)
 toggle_packages(csc_cython_ENABLED, "xpra.codecs.csc_cython")
 tace(csc_cython_ENABLED, "xpra.codecs.csc_cython.converter", optimize=3)
 toggle_packages(pytorch_ENABLED, "xpra.codecs.pytorch")


### PR DESCRIPTION
## Summary

- Detect the standard `libyuv.h` header on supported Unix systems when pkg-config metadata is unavailable, allowing Ubuntu 26.04's `libyuv-dev` package to enable the converter.
- Keep pkg-config authoritative when available and otherwise pass the direct `-lyuv` linkage using the same inline fallback pattern as the existing PAM build logic.
- Preserve the existing platform gates and explicit enable or disable behavior.

No matching Xpra issue or pull request was found.

## Test plan

- [x] Clean Ubuntu 26.04 fallback build without `libyuv.pc`, including converter import, ELF dependency checks, and BGRX-to-NV12 conversion
- [x] Explicit enable without usable dependencies fails clearly; explicit disable remains disabled
- [x] Focused Cython-enabled client/libyuv build and relevant codec tests
- [x] Full interpreted unit-test suite: 272 successful, 0 failed, 7 intended skips
- [x] Ruff, Flake8, and `git diff --check`