### PR TITLE
Register the native libva video decoder

### DIFF
--- a/tests/unittests/unit/codecs/video_helper_test.py
+++ b/tests/unittests/unit/codecs/video_helper_test.py
@@ -21,6 +21,16 @@ class VideoHelperTest(unittest.TestCase):
         with patch.object(video, "find_spec", side_effect=ImportError):
             self.assertFalse(video.has_codec_module("broken"))
 
+    def test_libva_decoder_registration(self):
+        self.assertEqual(video.CODEC_TO_MODULE["dec_libva"], "libva.decoder")
+        self.assertIn("libva", video.ALL_VIDEO_DECODER_OPTIONS)
+        with patch.object(video, "has_codec_module", return_value=True) as has_codec_module:
+            self.assertEqual(video.get_video_decoders(("libva",)), ["dec_libva"])
+        has_codec_module.assert_called_once_with("libva.decoder")
+        helper = video.VideoHelper()
+        helper.set_modules(video_decoders=("libva",))
+        self.assertEqual(helper.decoders, {"dec_libva": {}})
+
     def test_filter_and_option_parsing(self):
         result = video.filt("enc", "encoders", ("x264:quality=80", "no-vpx", "unknown"),
                             lambda: ["enc_x264", "enc_vpx"], ("x264", "vpx"))

--- a/xpra/codecs/video.py
+++ b/xpra/codecs/video.py
@@ -36,6 +36,7 @@ CODEC_TO_MODULE: dict[str, str] = {
     "nvenc"         : "nvidia.nvenc",
     "enc_vpl"       : "vpl.encoder",
     "enc_libva"     : "libva.encoder",
+    "dec_libva"     : "libva.decoder",
     "nvdec"         : "nvidia.nvdec",
     "csc_cython"    : "csc_cython.converter",
     "csc_libyuv"    : "libyuv.converter",
@@ -77,7 +78,7 @@ ALL_VIDEO_ENCODER_OPTIONS: Sequence[str] = ("amf", "vt", "x264", "openh264", "vp
                                             "nvenc", "vpl", "libva", "nvjpeg", "jpeg", "webp", "remote")
 HARDWARE_ENCODER_OPTIONS: Sequence[str] = ("nvenc", "vpl", "libva", "nvjpeg", "vt")
 ALL_CSC_MODULE_OPTIONS: Sequence[str] = ("cython", "libyuv")
-ALL_VIDEO_DECODER_OPTIONS: Sequence[str] = ("vpl", "mf", "nvdec", "openh264", "vpx", "dav1d", "aom", "de265")
+ALL_VIDEO_DECODER_OPTIONS: Sequence[str] = ("vpl", "mf", "nvdec", "libva", "openh264", "vpx", "dav1d", "aom", "de265")
 
 PREFERRED_ENCODER_ORDER: Sequence[str] = tuple(
     autoprefix("enc", x) for x in (


### PR DESCRIPTION
## Summary

- Register the existing native libva decoder with the video helper so `--video-decoders=libva` reaches `dec_libva` instead of being discarded as unknown.
- Submit the decoder registration from #4964 separately, following the review request to split that pull request into smaller changes.

The missing registration was reproduced while configuring hardware-accelerated streaming on Ubuntu 26.04.

## Test plan

- [x] Run the focused video helper tests with hardware discovery mocked.
- [x] Run the full interpreted unit-test suite.
- [x] Build the native decoder cleanly and decode bundled H.264 frames through `/dev/dri/renderD128` using Mesa radeonsi.