### PR TITLE
tests: fix host-dependent failures

### DIFF
--- a/tests/unittests/unit/net/peer_uid_test.py
+++ b/tests/unittests/unit/net/peer_uid_test.py
@@ -13,7 +13,35 @@ from xpra.os_util import LINUX, POSIX
 from xpra.net.common import get_peer_uid, proc_net_addr, proc_net_addr_keys
 
 
+def has_ipv6(host="::1") -> bool:
+    """
+        `socket.has_ipv6` only tells us that Python was built with IPv6 support,
+        it does not tell us that this host can bind `host`:
+        kernels booted with `ipv6.disable=1` cannot even create an IPv6 socket,
+        and hosts with `net.ipv6.conf.all.disable_ipv6=1` can create one
+        but have no address left to bind it to.
+    """
+    if not socket.has_ipv6:
+        return False
+    try:
+        sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    except OSError:
+        return False
+    try:
+        sock.bind((host, 0))
+    except OSError:
+        return False
+    finally:
+        sock.close()
+    return True
+
+
 class TestPeerUID(unittest.TestCase):
+
+    def test_has_ipv6_unassigned_address(self):
+        # the probe must bind and not just create a socket:
+        # this RFC 3849 documentation address is never assigned to a local interface
+        assert not has_ipv6("2001:db8::1")
 
     def test_proc_net_addr(self):
         # the 32 bit words are in host byte order, the port is not:
@@ -58,14 +86,21 @@ class TestPeerUID(unittest.TestCase):
             (socket.AF_INET, ("127.0.0.1", 0)),
             (socket.AF_INET6, ("::1", 0)),
         ):
-            conn, client = self.connect_pair(family, address)
-            # both ends of a local connection can identify each other:
-            assert get_peer_uid(conn) == uid, f"expected uid {uid} for {family}"
-            assert get_peer_uid(client) == uid, f"expected uid {uid} for {family}"
+            with self.subTest(family=family):
+                if family == socket.AF_INET6 and not has_ipv6():
+                    self.skipTest("no IPv6 support on this host")
+                conn, client = self.connect_pair(family, address)
+                # both ends of a local connection can identify each other:
+                assert get_peer_uid(conn) == uid, f"expected uid {uid} for {family}"
+                assert get_peer_uid(client) == uid, f"expected uid {uid} for {family}"
 
     def test_local_tcp_v4mapped(self):
         if not LINUX:
             return
+        # this test only needs the wildcard address, which is still bindable
+        # on hosts where `::1` has been removed from the loopback interface:
+        if not has_ipv6("::"):
+            self.skipTest("no IPv6 support on this host")
         # an IPv4 client connecting to an IPv6 socket:
         conn, client = self.connect_pair(socket.AF_INET6, ("::", 0), socket.AF_INET, "127.0.0.1")
         uid = os.getuid()

--- a/tests/unittests/unit/net/socket_util_test.py
+++ b/tests/unittests/unit/net/socket_util_test.py
@@ -320,6 +320,47 @@ class TestCloseSockets(unittest.TestCase):
         assert cleanup_called
 
 
+def has_ipv6(host="::1") -> bool:
+    """
+        `socket.has_ipv6` only tells us that Python was built with IPv6 support,
+        it does not tell us that this host can bind `host`:
+        kernels booted with `ipv6.disable=1` cannot even create an IPv6 socket,
+        and hosts with `net.ipv6.conf.all.disable_ipv6=1` can create one
+        but have no address left to bind it to.
+    """
+    if not socket.has_ipv6:
+        return False
+    try:
+        sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+    except OSError:
+        return False
+    try:
+        sock.bind((host, 0))
+    except OSError:
+        return False
+    finally:
+        sock.close()
+    return True
+
+
+class TestHasIPv6(unittest.TestCase):
+
+    def test_unassigned_address(self):
+        # the probe must bind and not just create a socket:
+        # this RFC 3849 documentation address is never assigned to a local interface
+        assert not has_ipv6("2001:db8::1")
+
+    def test_loopback_can_be_bound(self):
+        # whatever the probe says yes to must really be bindable:
+        if not has_ipv6():
+            self.skipTest("no IPv6 support on this host")
+        sock = socket.socket(socket.AF_INET6, socket.SOCK_STREAM)
+        try:
+            sock.bind(("::1", 0))
+        finally:
+            sock.close()
+
+
 class TestCreateTcpSocket(unittest.TestCase):
 
     def test_ipv4(self):
@@ -330,8 +371,8 @@ class TestCreateTcpSocket(unittest.TestCase):
             sock.close()
 
     def test_ipv6(self):
-        if not socket.has_ipv6:
-            return
+        if not has_ipv6():
+            self.skipTest("no IPv6 support on this host")
         sock = create_tcp_socket("::1", 0)
         try:
             assert sock.family == socket.AF_INET6

--- a/tests/unittests/unit/server/source/mmap_test.py
+++ b/tests/unittests/unit/server/source/mmap_test.py
@@ -8,8 +8,10 @@ import os
 import hashlib
 import tempfile
 import unittest
+from contextlib import contextmanager
 
 from xpra.os_util import POSIX
+from xpra.util.env import OSEnvContext
 from xpra.util.objects import AdHocStruct, typedict
 from xpra.net.mmap.common import DEFAULT_TOKEN_BYTES, MIN_SIZE
 from xpra.net.mmap.io import init_client_mmap, write_mmap_token
@@ -17,6 +19,24 @@ from xpra.server.source import mmap as source_mmap
 from xpra.server.source.mmap import MMAP_Connection
 
 from unit.test_util import silence_warn, silence_error, silence_info
+
+
+@contextmanager
+def temp_runtime_dir():
+    """
+        A throw-away `XDG_RUNTIME_DIR` so that the default mmap directories
+        can be exercised even on hosts which have no runtime directory of their own
+        (containers, CI images, and any session started without one).
+        The directory is named after our uid - the standard `/run/user/$UID` layout -
+        so that `get_runtime_dir` still returns a `$UID` template
+        which can also be expanded for another user.
+        Yields the parent directory: `{parent}/{uid}/xpra` is then our own mmap directory.
+    """
+    with tempfile.TemporaryDirectory() as parent:
+        runtime_dir = os.path.join(parent, str(os.geteuid()))
+        os.mkdir(runtime_dir, 0o700)
+        with OSEnvContext(XDG_RUNTIME_DIR=runtime_dir):
+            yield parent
 
 
 def make_source(dirs=(), files=(), peer_uid=-1) -> MMAP_Connection:
@@ -65,22 +85,24 @@ class MmapPathTest(unittest.TestCase):
     def test_default_dirs_only(self):
         if not POSIX:
             return
-        source = make_source()
-        allowed = source.allowed_dirs
-        assert allowed, "no default mmap directory found"
-        # a file in an allowed directory is accepted:
-        filename = os.path.join(allowed[0], "xpra.1234.mmap")
-        self.assertEqual(self.path(source, filename), filename)
-        # anything else is refused:
-        for filename in (
-            "/etc/passwd",
-            "/tmp/xpra.1234.mmap",
-            os.path.expanduser("~/.ssh/id_rsa"),
-            # the directory is only matched after normalization,
-            # so traversal cannot be used to escape it:
-            os.path.join(allowed[0], "..", "..", "etc", "passwd"),
-        ):
-            self.assertEqual(self.path(source, filename), "", f"{filename!r} should have been refused")
+        with temp_runtime_dir() as parent:
+            source = make_source()
+            allowed = source.allowed_dirs
+            assert allowed, "no default mmap directory found"
+            self.assertEqual(allowed[0], os.path.join(parent, str(os.getuid()), "xpra"))
+            # a file in an allowed directory is accepted:
+            filename = os.path.join(allowed[0], "xpra.1234.mmap")
+            self.assertEqual(self.path(source, filename), filename)
+            # anything else is refused:
+            for filename in (
+                "/etc/passwd",
+                "/tmp/xpra.1234.mmap",
+                os.path.expanduser("~/.ssh/id_rsa"),
+                # the directory is only matched after normalization,
+                # so traversal cannot be used to escape it:
+                os.path.join(allowed[0], "..", "..", "etc", "passwd"),
+            ):
+                self.assertEqual(self.path(source, filename), "", f"{filename!r} should have been refused")
 
     def test_no_filename(self):
         source = make_source()
@@ -88,28 +110,31 @@ class MmapPathTest(unittest.TestCase):
         self.assertEqual(self.path(source, "/some/dir/"), "")
 
     def test_peer_uid_directory(self):
-        if not POSIX or not os.path.isdir("/run/user"):
+        if not POSIX:
             return
         # a peer belonging to another user is allowed to use that user's mmap directory:
         uid = os.getuid() + 1
-        source = make_source(peer_uid=uid)
-        peer_dir = f"/run/user/{uid}/xpra"
-        self.assertIn(peer_dir, source.allowed_dirs)
-        filename = f"{peer_dir}/xpra.1234.mmap"
-        self.assertEqual(self.path(source, filename), filename)
-        # our own directory is still allowed:
-        assert len(source.allowed_dirs) >= 2
-        # but not another user's:
-        other = f"/run/user/{uid + 1}/xpra/xpra.1234.mmap"
-        self.assertEqual(self.path(source, other), "")
+        with temp_runtime_dir() as parent:
+            source = make_source(peer_uid=uid)
+            peer_dir = os.path.join(parent, str(uid), "xpra")
+            self.assertIn(peer_dir, source.allowed_dirs)
+            filename = f"{peer_dir}/xpra.1234.mmap"
+            self.assertEqual(self.path(source, filename), filename)
+            # our own directory is still allowed:
+            assert len(source.allowed_dirs) >= 2
+            # but not another user's:
+            other = os.path.join(parent, str(uid + 1), "xpra", "xpra.1234.mmap")
+            self.assertEqual(self.path(source, other), "")
 
     def test_unknown_peer_uid(self):
         if not POSIX:
             return
         # without a peer uid, only our own directory is allowed:
-        source = make_source(peer_uid=-1)
-        for mmap_dir in source.allowed_dirs:
-            assert not mmap_dir.startswith("/run/user/") or str(os.getuid()) in mmap_dir
+        with temp_runtime_dir() as parent:
+            source = make_source(peer_uid=-1)
+            self.assertEqual(tuple(source.allowed_dirs), (os.path.join(parent, str(os.getuid()), "xpra"), ))
+            other = os.path.join(parent, str(os.getuid() + 1), "xpra", "xpra.1234.mmap")
+            self.assertEqual(self.path(source, other), "")
 
 
 class ParseAreaCapsTest(unittest.TestCase):


### PR DESCRIPTION
Had some environment-specific testing issues pop up.
My environment is weird, so this one might not really be necessary more generally.
Two unit test groups fail on hosts without IPv6 or without `/run/user/$UID`:

- `socket.has_ipv6` is a build-time constant, so the IPv6 socket tests fail
  on kernels booted with `ipv6.disable=1`: probe by actually creating an
  `AF_INET6` socket, and skip when that fails.
- the mmap default-directory tests relied on `/run/user/$UID` existing:
  point `XDG_RUNTIME_DIR` at a temporary uid-named directory instead, and
  assert the computed default directory exactly.

Disclaimer: this code was fully vibe-implemented (fable 5), fully vibe-reviewed (fable 5), and human tested.
I have not looked at a single line of this code.
Totally fine with whatever outcome for this PR; it was fun to work on regardless :-)
