### PR TITLE
x11 bindings: link the xkb module against libX11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3430,7 +3430,7 @@ if x11_ENABLED:
         ace("xpra.x11.bindings.keyboard", "xkbfile")
         ace("xpra.x11.bindings.res", "xres")
         ace("xpra.x11.bindings.composite", "xcomposite")
-        ace("xpra.x11.bindings.xkb", "xkbfile")
+        ace("xpra.x11.bindings.xkb", "xkbfile,x11")
         ace("xpra.x11.bindings.saveset", "x11")
         ace("xpra.x11.bindings.classhint", "x11")
         ace("xpra.x11.bindings.shm", "xext")


### PR DESCRIPTION
`xpra.x11.bindings.xkb` calls `XDefaultRootWindow` but only links against
`libxkbfile`. On toolchains where `xkbfile.pc` does not pull in `x11`
transitively (seen on Ubuntu 26.04 with `python3 setup.py install`), the
import fails with `undefined symbol: XDefaultRootWindow` and the server
falls back to "Warning: XKB bindings not available", silently disabling
part of the modifier state synchronization.

Disclaimer: this code was fully vibe-implemented (fable 5), fully vibe-reviewed (fable 5), and human tested.
I have not looked at a single line of this code.
Totally fine with whatever outcome for this PR; it was fun to work on regardless :-)
