### PR TITLE
x11 bindings: only match `PropertyNewValue` events in `get_server_time`

### DIFF
--- a/xpra/x11/bindings/window.pyx
+++ b/xpra/x11/bindings/window.pyx
@@ -16,7 +16,7 @@ from xpra.x11.bindings.xlib cimport (
     Expose,
     XEvent,
     XWMHints, XSizeHints,
-    XCreateWindow, XDestroyWindow, XIfEvent, PropertyNotify,
+    XCreateWindow, XDestroyWindow, XIfEvent, PropertyNotify, PropertyNewValue,
     XSetWindowAttributes,
     XWindowAttributes, XWindowChanges,
     XDefaultRootWindow,
@@ -979,8 +979,14 @@ ctypedef struct xifevent_timestamp:
 
 cdef Bool timestamp_predicate(Display *display, XEvent  *xevent, XPointer arg)  noexcept nogil:
     cdef xifevent_timestamp *et = <xifevent_timestamp*> arg
-    cdef Window xwindow = <Window> arg
     if xevent.type!=PropertyNotify:
+        return False
+    # only match the `NewValue` notification of the property we just changed:
+    # the `XDeleteProperty` which follows in `get_server_time` generates a
+    # `Deleted` notification for the same window and atom, and matching that
+    # one on the next call would return a stale timestamp - which makes the
+    # X server silently ignore `XSetInputFocus`
+    if xevent.xproperty.state!=PropertyNewValue:
         return False
     return xevent.xproperty.window==et.window and xevent.xproperty.atom==et.atom
 

--- a/xpra/x11/bindings/xlib.pxd
+++ b/xpra/x11/bindings/xlib.pxd
@@ -33,6 +33,7 @@ cdef extern from "X11/X.h":
     unsigned long AnyPropertyType
     unsigned int PropModeReplace
     unsigned int PropertyNotify
+    unsigned int PropertyNewValue
     unsigned int Expose
 
 
@@ -510,6 +511,7 @@ cdef extern from "X11/Xlib.h":
         Window window
         Atom atom
         Time time
+        int state
     ctypedef struct XKeyEvent:
         unsigned int state
         unsigned int keycode


### PR DESCRIPTION
`get_server_time` changes a property and waits for the `PropertyNotify`,
but deleting the property afterwards queues a second notify with state
`PropertyDeleted`. The predicate matched both, so every call after the
first consumed the previous call's leftover event and returned a stale
timestamp — two successive calls return the same value. The X server
silently ignores `XSetInputFocus` with a timestamp older than the last
focus change, so focus handling could quietly stop working.

The `xlib.pxd` declarations (`XPropertyEvent.state`, `PropertyNewValue`)
ride along because the predicate cannot compile without them.

Disclaimer: this code was fully vibe-implemented (fable 5), fully vibe-reviewed (fable 5), and human tested.
I have not looked at a single line of this code.
Totally fine with whatever outcome for this PR; it was fun to work on regardless :-)
