### PR TITLE
keyboard: always send the `sync` value in the keymap properties

### DIFF
--- a/xpra/client/gui/keyboard_helper.py
+++ b/xpra/client/gui/keyboard_helper.py
@@ -406,7 +406,6 @@ class KeyboardHelper:
                 "backend", "backend_name",
                 "layout", "layouts", "variant", "variants", "options",
                 "raw", "layout_groups",
-                "sync",
                 "query_struct", "mod_meanings",
                 "mod_managed", "mod_pointermissing", "keycodes", "x11_keycodes",
         ):
@@ -420,6 +419,10 @@ class KeyboardHelper:
                 v = getattr(self, x)
             if v:
                 props[x] = v
+        if "sync" not in skip:
+            # the server defaults `sync` to `True` (`boolget`),
+            # so a `False` value must always be sent explicitly:
+            props["sync"] = bool(self.sync)
         return props
 
     def log_keyboard_info(self) -> None:


### PR DESCRIPTION
`get_keymap_properties` only includes truthy values, so `sync=False` was
dropped and the server's `parse_options` fell back to
`boolget("sync", True)`: `--keyboard-sync=no` was ignored by the server
for every client. Set `sync` explicitly after the truthiness-filtered
loop instead of listing it with the optional properties.

This is the client-side counterpart of #4963. Old servers parse the extra key fine (`boolget`).
Behavior change: users with `keyboard-sync=no` in a config file get it honored for the first time.

Verified with `-d keyboard` on both ends: the server now logs
`sync=False` in `handle_key` and does the immediate press-and-release.

Disclaimer: this code was fully vibe-implemented (fable 5), fully vibe-reviewed (fable 5), and human tested.
I have not looked at a single line of this code.
Totally fine with whatever outcome for this PR; it was fun to work on regardless :-)
