### PR TITLE
desktop: add the missing RandR mode for any virtual display, not just dummy

### DIFF
--- a/xpra/x11/desktop/desktop_model.py
+++ b/xpra/x11/desktop/desktop_model.py
@@ -120,7 +120,13 @@ class ScreenDesktopModel(DesktopModelBase):
             if ow == rw and oh == rh:
                 return
             with xsync:
-                if RandR.is_dummy16() and (rw, rh) not in RandR.get_xrr_screen_sizes():
+                if (rw, rh) not in RandR.get_xrr_screen_sizes():
+                    # the mode must exist before it can be set: this is not
+                    # specific to the dummy driver, Xvfb needs it too
+                    # (the seamless server adds missing modes whenever
+                    # `randr_exact_size` is set, which covers both the dummy
+                    # driver and Xvfb - see `do_get_best_screen_size`
+                    # in `xpra.x11.subsystem.display`):
                     RandR.add_screen_size(rw, rh)
             with xsync:
                 if not RandR.set_screen_size(rw, rh):


### PR DESCRIPTION
`ScreenDesktopModel.do_resize` only added the requested mode on the dummy
driver, so resizing a desktop session running on Xvfb silently did
nothing: `set_screen_size` cannot switch to a mode that does not exist,
and Xvfb only pre-defines its initial resolution. Repro: `xpra
start-desktop --resize-display=yes` on Xvfb, resize the client window —
the log shows `wanted WxH - got <initial size>` and nothing changes.

The seamless server already adds missing modes whenever
`randr_exact_size` is set (covers both dummy and Xvfb, see
`do_get_best_screen_size`) — do the same here.

Disclaimer: this code was fully vibe-implemented (fable 5), fully vibe-reviewed (fable 5), and human tested.
I have not looked at a single line of this code.
Totally fine with whatever outcome for this PR; it was fun to work on regardless :-)
