### PR TITLE
Fix Debian upgrades to the split Wayland package

### DIFF
--- a/packaging/debian/xpra/control
+++ b/packaging/debian/xpra/control
@@ -235,6 +235,8 @@ Description: tool to detach/reattach running X programs,
 
 Package: xpra-wayland
 Architecture: any
+Breaks: xpra-common (<< ${binary:Version})
+Replaces: xpra-common (<< ${binary:Version})
 Depends: xpra-common (= ${binary:Version})
         ,${misc:Depends}
         ,${python3:Depends}


### PR DESCRIPTION
## Summary

- Allow `xpra-wayland` to take ownership of Wayland files shipped by older `xpra-common` packages, preventing dpkg overwrite failures during upgrades from Xpra 6.5.3 to the 6.6 beta packages on Ubuntu 26.04.
- Add versioned `Breaks` and `Replaces` relationships while retaining the exact-version `xpra-common` dependency, so the current packages remain installed together.

The upgrade failed with:

```text
dpkg: error processing archive /tmp/apt-dpkg-install-j0TSB3/36-xpra-wayland_6.6-r42294-1_amd64.deb (--unpack):
 trying to overwrite '/usr/lib/python3/dist-packages/xpra/wayland/__init__.py', which is also in package xpra-common (6.5.3-r0-1)
```

No matching Xpra issue or pull request was found.

## Test plan

- [x] Generate the binary package relationships with `dpkg-gencontrol` and verify the versioned transition fields.
- [x] Reproduce the pre-fix overwrite failure, then verify the same unpack order transfers file ownership and leaves both current packages configured.
- [x] Run the full interpreted unit-test suite: 273 successful, 0 failed, 7 requested slow-test exclusions.