### PR TITLE
Fix GTK3 OpenGL presentation without configure events

### DIFF
--- a/tests/unittests/unit/client/gtk3/opengl_client_window_test.py
+++ b/tests/unittests/unit/client/gtk3/opengl_client_window_test.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python3
+# This file is part of Xpra.
+# Copyright (C) 2026 kogeler <25884155+kogeler@users.noreply.github.com>
+# Xpra is released under the terms of the GNU GPL v2, or, at your option, any
+# later version. See the file COPYING for details.
+
+import unittest
+
+from xpra.client.gtk3.opengl.client_window import GLClientWindowBase
+
+
+class FakeBacking:
+
+    def __init__(self) -> None:
+        self.paint_screen = False
+        self.presented = False
+
+    def draw_fbo(self, context) -> object:
+        assert self.paint_screen
+        self.presented = True
+        return context
+
+
+class FakeWindow:
+
+    def __init__(self, backing: FakeBacking | None, mapped: bool = True) -> None:
+        self._backing = backing
+        self.mapped = mapped
+
+    def get_mapped(self) -> bool:
+        return self.mapped
+
+
+class OpenGLClientWindowTest(unittest.TestCase):
+
+    def test_mapped_draw_enables_screen_paint_before_presenting(self) -> None:
+        backing = FakeBacking()
+        window = FakeWindow(backing)
+        context = object()
+
+        result = GLClientWindowBase.draw_widget(window, object(), context)
+
+        self.assertIs(result, context)
+        self.assertTrue(backing.paint_screen)
+        self.assertTrue(backing.presented)
+
+    def test_unmapped_draw_does_not_enable_screen_paint(self) -> None:
+        backing = FakeBacking()
+        window = FakeWindow(backing, mapped=False)
+
+        result = GLClientWindowBase.draw_widget(window, object(), object())
+
+        self.assertFalse(result)
+        self.assertFalse(backing.paint_screen)
+        self.assertFalse(backing.presented)
+
+
+def main() -> None:
+    unittest.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/xpra/client/gtk3/opengl/client_window.py
+++ b/xpra/client/gtk3/opengl/client_window.py
@@ -111,4 +111,5 @@ class GLClientWindowBase(ClientWindow):
             return False
         if not backing:
             return False
+        backing.paint_screen = True
         return backing.draw_fbo(context)


### PR DESCRIPTION
## Problem

A mapped GTK3 OpenGL client window remained transparent even though frames continued through the rest of the pipeline. The reproduced setup used an AMD GPU, a Wayland server running a Vulkan workload, native VA-API H.264 encoding and decoding, direct NV12 OpenGL rendering, and an X11 GTK3 client. Input and frame processing continued, which isolated the failure to final FBO presentation.

`paint_screen` starts disabled and was previously enabled only by `do_configure_event()`. GTK can draw a mapped widget without first emitting a configure event, leaving `present_fbo()` to queue updates without presenting them.

## Change

Enable `paint_screen` at the mapped GTK3 draw boundary immediately before `draw_fbo()`. The existing behavior for unmapped windows and missing backings remains unchanged.

## Test plan

- [x] Focused regression test against interpreted and Cython-built code
- [x] Baseline, `cythonize_more`, and no-backwards-compatibility unit-test legs: 277 successful, 0 failed, 7 configured skips in each
- [x] Ruff on the new test, Flake8 on both changed files, and `git diff --check`