### PR TITLE
Test Wayland configure client properties

### DIFF
--- a/tests/unittests/unit/wayland/window_test.py
+++ b/tests/unittests/unit/wayland/window_test.py
@@ -9,6 +9,8 @@ import unittest
 from types import ModuleType
 from unittest.mock import Mock, patch
 
+from xpra.util.objects import typedict
+
 
 def load_window_server_class():
     modules = {}
@@ -99,6 +101,84 @@ class WaylandWindowServerCommitTest(unittest.TestCase):
 
         server.get_surface.assert_not_called()
         server.refresh_window_area.assert_not_called()
+
+
+class WaylandWindowServerConfigureTest(unittest.TestCase):
+
+    @staticmethod
+    def make_server(window, surface):
+        server = Mock()
+        server.get_window.return_value = window
+        server.get_surface.return_value = surface
+        return server
+
+    def test_property_only_configure_updates_client_properties(self):
+        proto = Mock()
+        window = Mock()
+        surface = Mock()
+        server = self.make_server(window, surface)
+        properties = {"encodings.rgb_formats": ("RGBX",)}
+
+        WaylandWindowServer.do_process_window_configure(
+            server, proto, 7, typedict({"properties": properties}),
+        )
+
+        server._set_client_properties.assert_called_once_with(proto, 7, window, properties)
+        surface.resize.assert_not_called()
+        surface.frame_done.assert_not_called()
+        server.server.compositor.flush.assert_not_called()
+
+    def test_properties_are_applied_before_geometry(self):
+        proto = Mock()
+        window = Mock()
+        surface = Mock()
+        server = self.make_server(window, surface)
+        properties = {"encodings.rgb_formats": ("RGBX",)}
+        events = []
+        server._set_client_properties.side_effect = lambda *_args: events.append("properties")
+        surface.resize.side_effect = lambda *_args: events.append("resize")
+        surface.frame_done.side_effect = lambda: events.append("frame-done")
+        server.server.compositor.flush.side_effect = lambda: events.append("flush")
+
+        WaylandWindowServer.do_process_window_configure(
+            server,
+            proto,
+            7,
+            typedict({
+                "properties": properties,
+                "geometry": (10, 20, 800, 600),
+            }),
+        )
+
+        self.assertEqual(events, ["properties", "resize", "frame-done", "flush"])
+        server._set_client_properties.assert_called_once_with(proto, 7, window, properties)
+        surface.resize.assert_called_once_with(800, 600)
+        surface.frame_done.assert_called_once_with()
+        server.server.compositor.flush.assert_called_once_with()
+
+    def test_missing_window_or_surface_is_ignored(self):
+        proto = Mock()
+        properties = {"encodings.rgb_formats": ("RGBX",)}
+        config = typedict({
+            "properties": properties,
+            "geometry": (10, 20, 800, 600),
+        })
+        cases = (
+            ("window", None, Mock()),
+            ("surface", Mock(), None),
+        )
+
+        for missing, window, surface in cases:
+            with self.subTest(missing=missing):
+                server = self.make_server(window, surface)
+
+                WaylandWindowServer.do_process_window_configure(server, proto, 7, config)
+
+                server._set_client_properties.assert_not_called()
+                if surface is not None:
+                    surface.resize.assert_not_called()
+                    surface.frame_done.assert_not_called()
+                server.server.compositor.flush.assert_not_called()
 
 
 def main():


### PR DESCRIPTION
Follow-up to https://github.com/Xpra-org/xpra/issues/5020 and the fix in
https://github.com/Xpra-org/xpra/commit/e1aaa640d5f49e1f1f82b896a8a94fc698f347ec.

## Problem

The configure-property fix added in `e1aaa640` has no focused regression test.

## Change

Add regression coverage for configure client-property forwarding on the
Wayland server. The tests cover property-only updates, verify that properties
are applied before geometry, and keep the missing-window and missing-surface
paths as no-ops.

This PR changes tests only.

## Validation

The three current changes were validated together on canonical Xpra
[`521db02`](https://github.com/Xpra-org/xpra/commit/521db02f143d9f0a57c656658d9ee12572622276).
The focused regressions passed 24/24 tests, and the native Wayland gate passed
15/15 tests plus its build, import, and linkage checks.

In each full mode—baseline, Cython-expanded, and no backward compatibility—
all 292 other test modules and every module changed by this patch set passed.
The sole failing module was the new upstream
`unit.client.x11_client_paint_test`; it fails on the unmodified commit and in
all three jobs of [upstream's own Actions run](https://github.com/Xpra-org/xpra/actions/runs/32871771151),
so it is not caused by these changes.

In the physical Zed/RADV workload, unmodified master passed RGB but reproduced
the strict H.264 startup error before map properties arrived. With the three
changes applied, RGB passed with 11 RGB-only updates, and H.264 passed with 18
H.264-only updates, no pre-negotiation pipeline error, and a contiguous
16-frame VA `EncSlice`/`VLD` stream presented as NV12 through AMD OpenGL.
Pixels, pointer input, lifecycle, and cleanup passed in both patched runs.

<details>
<summary>Focused regression command</summary>

```bash
CFLAGS='-O0 -g0' CXXFLAGS='-O0 -g0' \
EXTRA_ARGS='--with-terminal_client --with-wayland_server' \
python3 setup.py unittests unit/wayland/window_test.py
```

</details>

<details>
<summary>Wayland boundary command</summary>

```bash
CFLAGS='-O0 -g0' CXXFLAGS='-O0 -g0' \
EXTRA_ARGS='--minimal --with-modules --with-server --with-wayland_server' \
python3 setup.py unittests unit/wayland
```

</details>
