### PR TITLE
Wait for valid Wayland initial window state

### DIFF
--- a/tests/unittests/unit/server/subsystem/window_test.py
+++ b/tests/unittests/unit/server/subsystem/window_test.py
@@ -8,12 +8,47 @@ import unittest
 from unittest.mock import Mock, patch
 
 from xpra.net.common import Packet
+from xpra.net.packet_type import WINDOW_CREATE
 from xpra.util.objects import AdHocStruct, typedict
 from unit.test_util import stubbable
 from unit.server.subsystem.servermixintest_util import ServerMixinTest
 
 
 class WebcamMixinTest(ServerMixinTest):
+
+    @staticmethod
+    def make_initial_window_server(geometry):
+        from xpra.server.subsystem.window import WindowServer
+
+        server = object.__new__(WindowServer)
+        window = Mock()
+        window.is_managed.return_value = True
+        window.is_tray.return_value = False
+        window.is_OR.return_value = False
+        window.get_property.return_value = geometry
+        server._id_to_window = {1: window}
+        server.client_properties = {}
+        return server, window
+
+    def test_initial_window_waits_for_nonzero_dimensions(self):
+        server, window = self.make_initial_window_server((10, 20, 0, 0))
+        source = Mock(uuid="client")
+
+        server.send_initial_windows(source)
+
+        window.hide.assert_not_called()
+        source.new_window.assert_not_called()
+        source.damage.assert_not_called()
+
+        server, window = self.make_initial_window_server((10, 20, 800, 600))
+        source = Mock(uuid="client")
+
+        server.send_initial_windows(source)
+
+        source.new_window.assert_called_once_with(
+            WINDOW_CREATE, 1, window, 10, 20, 800, 600, {},
+        )
+        source.damage.assert_called_once_with(1, window, 0, 0, 800, 600)
 
     def test_window_stacking_packet(self):
         from xpra.server.subsystem.window import WindowServer

--- a/tests/unittests/unit/server/window/initial_damage_test.py
+++ b/tests/unittests/unit/server/window/initial_damage_test.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# This file is part of Xpra.
+# Copyright (C) 2026 Antoine Martin <antoine@xpra.org>
+# Xpra is released under the terms of the GNU GPL v2, or, at your option, any
+# later version. See the file COPYING for details.
+
+import unittest
+from unittest.mock import patch
+
+from xpra.server.window.compress import WindowSource
+from xpra.server.window.subsurface_source import SubsurfaceWindowSource
+from xpra.server.window.video_compress import WindowVideoSource
+from xpra.util.objects import typedict
+
+
+class InitialDamageTest(unittest.TestCase):
+
+    @staticmethod
+    def make_source(source_class: type[WindowVideoSource] = WindowVideoSource) -> WindowVideoSource:
+        source = object.__new__(source_class)
+        source.wid = 1
+        source._client_csc_modes_resolved = False
+        source.is_OR = False
+        source.is_tray = False
+        source.is_shadow = False
+        source.common_video_encodings = ("h264",)
+        source.non_video_encodings = ()
+        source.full_csc_modes = typedict()
+        return source
+
+    @staticmethod
+    def damage(source: WindowVideoSource) -> bool:
+        with patch.object(WindowSource, "damage") as damage:
+            source.damage(0, 0, 800, 600)
+        return damage.called
+
+    def set_properties(self, source: WindowVideoSource, properties: dict) -> None:
+        with patch.object(WindowSource, "set_client_properties") as set_properties:
+            source.set_client_properties(typedict(properties))
+        set_properties.assert_called_once()
+
+    def test_video_only_damage_waits_for_window_csc_modes(self):
+        source = self.make_source()
+
+        self.assertFalse(self.damage(source))
+
+        self.set_properties(source, {"event": "map"})
+        self.assertTrue(self.damage(source))
+
+    def test_explicit_empty_window_csc_modes_resolve_state(self):
+        source = self.make_source()
+
+        self.set_properties(source, {"encoding.full_csc_modes": {}})
+
+        self.assertTrue(source._client_csc_modes_resolved)
+        self.assertTrue(self.damage(source))
+
+    def test_subsurface_damage_does_not_wait_for_toplevel_map(self):
+        source = self.make_source(SubsurfaceWindowSource)
+        source.parent_wid = 9
+
+        self.assertTrue(self.damage(source))
+
+    def test_safe_initial_damage_paths_remain_immediate(self):
+        cases = {
+            "picture fallback": {"non_video_encodings": ("rgb24",)},
+            "global csc modes": {"full_csc_modes": typedict({"h264": ("YUV420P",)})},
+            "override redirect": {"is_OR": True},
+            "tray": {"is_tray": True},
+            "shadow": {"is_shadow": True},
+            "no video encoding": {"common_video_encodings": ()},
+        }
+        for name, values in cases.items():
+            with self.subTest(name=name):
+                source = self.make_source()
+                for key, value in values.items():
+                    setattr(source, key, value)
+                self.assertTrue(self.damage(source))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/unittests/unit/wayland/window_test.py
+++ b/tests/unittests/unit/wayland/window_test.py
@@ -30,6 +30,99 @@ def load_window_server_class():
 WaylandWindowServer = load_window_server_class()
 
 
+class WaylandWindowServerInitialWindowTest(unittest.TestCase):
+
+    @staticmethod
+    def make_server(geometry):
+        server = object.__new__(WaylandWindowServer)
+        window = Mock()
+        window.is_managed.return_value = True
+        window.is_tray.return_value = False
+        window.is_OR.return_value = False
+        window.get_property.return_value = geometry
+        server._id_to_window = {7: window}
+        server.client_properties = {}
+        return server, window
+
+    def test_zero_size_window_is_announced_once_when_ready(self):
+        from xpra.net.packet_type import WINDOW_CREATE
+
+        server, window = self.make_server((0, 0, 0, 0))
+        source = Mock(uuid="client")
+
+        with patch.object(WaylandWindowServer, "_do_send_new_window_packet") as send_window:
+            server.send_initial_windows(source)
+            server.update_size(window, (800, 600))
+            window.get_property.return_value = (0, 0, 800, 600)
+            server.update_size(window, (800, 600))
+
+        window.hide.assert_not_called()
+        source.new_window.assert_not_called()
+        source.damage.assert_not_called()
+        send_window.assert_called_once_with(
+            WINDOW_CREATE, window, (0, 0, 800, 600),
+        )
+
+    def test_map_applies_properties_before_first_refresh(self):
+        from xpra.net.common import Packet
+        from xpra.server.subsystem.window import WindowServer
+        from xpra.server.window.compress import WindowSource
+        from xpra.server.window.video_compress import WindowVideoSource
+
+        proto = Mock()
+        window = Mock()
+        surface = Mock()
+        server = Mock()
+        server.get_window.return_value = window
+        server.get_surface.return_value = surface
+        source = object.__new__(WindowVideoSource)
+        source.wid = 7
+        source._client_csc_modes_resolved = False
+        source.is_OR = False
+        source.is_tray = False
+        source.is_shadow = False
+        source.common_video_encodings = ("h264",)
+        source.non_video_encodings = ()
+        source.full_csc_modes = typedict()
+        connection = Mock(uuid="client")
+        server.get_server_source.return_value = connection
+        events = []
+
+        def set_client_properties(_wid, _window, properties):
+            events.append("properties")
+            source.set_client_properties(properties)
+
+        connection.set_client_properties.side_effect = set_client_properties
+        server._set_client_properties.side_effect = (
+            lambda *args: WindowServer._set_client_properties(server, *args)
+        )
+        surface.resize.side_effect = lambda *_args: events.append("resize")
+        server.server.compositor.flush.side_effect = lambda: events.append("flush")
+
+        def refresh_window(_window):
+            events.append("refresh")
+            source.damage(0, 0, 800, 600)
+
+        server.refresh_window.side_effect = refresh_window
+        properties = {"encoding.full_csc_modes": {"h264": ("YUV420P",)}}
+
+        with patch.object(WindowSource, "set_client_properties"), \
+                patch.object(WindowSource, "damage") as damage:
+            source.damage(0, 0, 800, 600)
+            damage.assert_not_called()
+
+            WaylandWindowServer._process_map(
+                server, proto, Packet("window-map", 7, 0, 0, 800, 600, properties),
+            )
+
+        self.assertEqual(events, ["properties", "resize", "flush", "refresh"])
+        self.assertTrue(source._client_csc_modes_resolved)
+        damage.assert_called_once_with(0, 0, 800, 600, None)
+        server._set_client_properties.assert_called_once_with(
+            proto, 7, window, properties | {"event": "map"},
+        )
+
+
 class WaylandWindowServerCommitTest(unittest.TestCase):
 
     @staticmethod

--- a/xpra/server/subsystem/window.py
+++ b/xpra/server/subsystem/window.py
@@ -634,9 +634,15 @@ class WindowServer(StubSubsystem):
                     window.move_resize(-200, -200, w, h)
             else:
                 # code more or less duplicated from _send_new_window_packet:
+                x, y, w, h = window.get_property("geometry")
+                # The Wayland backend registers a 0x0 model before its first
+                # valid commit. Its update_size() path sends the create packet
+                # when that model becomes ready.
+                if w == h == 0:
+                    log("not sending initial window %#x with zero dimensions", wid)
+                    continue
                 if not sharing and not window.is_OR():
                     window.hide()
-                x, y, w, h = window.get_property("geometry")
                 wprops = self.client_properties.get(wid, {}).get(ss.uuid, {})
                 packet_type = "new-override-redirect" if (window.is_OR() and BACKWARDS_COMPATIBLE) else WINDOW_CREATE
                 ss.new_window(packet_type, wid, window, x, y, w, h, wprops)

--- a/xpra/server/window/video_compress.py
+++ b/xpra/server/window/video_compress.py
@@ -231,6 +231,7 @@ class WindowVideoSource(WindowSource):
         self._csc_encoder: ColorspaceConverter | None = None
         self._video_encoder: VideoEncoder | None = None
         self._last_pipeline_check = 0
+        self._client_csc_modes_resolved = False
 
     def do_init_encoders(self) -> None:
         super().do_init_encoders()
@@ -280,6 +281,27 @@ class WindowVideoSource(WindowSource):
         super().do_set_auto_refresh_delay(min_delay, delay)
         if r := self.video_subregion:
             r.set_auto_refresh_delay(self.base_auto_refresh_delay)
+
+    def set_client_properties(self, properties: typedict) -> None:
+        if properties.strget("event") == "map" or isinstance(properties.get("encoding.full_csc_modes"), dict):
+            self._client_csc_modes_resolved = True
+        super().set_client_properties(properties)
+
+    def waiting_for_client_csc_modes(self) -> bool:
+        return all((
+            not self._client_csc_modes_resolved,
+            not getattr(self, "parent_wid", 0),
+            not (self.is_OR or self.is_tray or self.is_shadow),
+            bool(self.common_video_encodings),
+            not self.non_video_encodings,
+            not any(self.full_csc_modes.strtupleget(encoding) for encoding in self.common_video_encodings),
+        ))
+
+    def damage(self, x: int, y: int, w: int, h: int, options=None) -> None:
+        if self.waiting_for_client_csc_modes():
+            videolog("dropping damage for window %#x until client CSC modes are known", self.wid)
+            return
+        super().damage(x, y, w, h, options)
 
     def update_av_sync_frame_delay(self) -> None:
         self.av_sync_frame_delay = 0


### PR DESCRIPTION
Closes https://github.com/Xpra-org/xpra/issues/5022

## Problem

When a client attaches to a Wayland session, the initial-window pass can emit
state before the registered model is ready in either of two ways. A `0x0`
model can be announced before `update_size()` performs its normal first valid
announcement, or a valid-size video-only window can be damaged before the map
packet supplies its concrete backing's CSC modes. The latter enters H.264
pipeline selection with no usable mode and no picture fallback.

## Change

Leave an exact `0x0` Wayland model for the existing `update_size()` transition
to announce. For valid windows, delay damage only while a normal top-level,
video-only source has no fallback and its per-window CSC state is unresolved.
A map event or explicit per-window CSC dictionary releases damage. RGB,
picture fallback, usable global CSC, OR, tray, shadow, and subsurface paths
remain immediate.

## Validation

The atomic change was validated on canonical Xpra
[`1d8e112`](https://github.com/Xpra-org/xpra/commit/1d8e112c4a03c2ac6d56f9488843fc6ef2f7e57b).
The same test-only verification failed all five new production-path assertions
on unmodified master, while the atomic patch passed 21/21 focused tests. The
native Wayland gate passed its build, import, and linkage checks plus 15/15
tests.

Each full mode completed 292 modules successfully and reported one failure,
the unrelated `unit.client.x11_client_paint_test`. Canonical
[Actions run 32964054292](https://github.com/Xpra-org/xpra/actions/runs/32964054292)
on exact unmodified `1d8e112` has the same sole failed module and seven skips
in baseline, Cython-expanded, and no-backwards-compatibility jobs. This change
neither touches nor skips that test.

On the physical Zed/RADV workload, strict H.264 on unmodified master reproduced
the startup error before map properties arrived. Both proposed picture
fallback configurations made the application visible, but carried every
packet as `rgb32`: `--encodings=h264,rgb` produced 20 RGB and zero H.264
updates, while adding `--encoding=h264` produced seven RGB and zero H.264
updates. The patched strict run produced 19 H.264 and zero RGB updates with no
startup or pre-negotiation error. Hardware VA-API encode/decode, native NV12
OpenGL, pixels, pointer input, application capture, lifecycle, and cleanup all
passed. The patched RGB control also passed with 11 RGB-only updates.

<details>
<summary>Focused regression command</summary>

```bash
CFLAGS='-O0 -g0' CXXFLAGS='-O0 -g0' \
EXTRA_ARGS='--with-terminal_client' \
python3 setup.py unittests \
  unit/server/subsystem/window_test.py \
  unit/server/window/initial_damage_test.py \
  unit/wayland/window_test.py
```

</details>
