### PR TITLE
win32: do not swallow WM_INPUTLANGCHANGE, let GDK update its keymap

### DIFF
--- a/xpra/platform/win32/gtk.py
+++ b/xpra/platform/win32/gtk.py
@@ -160,10 +160,16 @@ def add_window_hooks(window) -> None:
                 apply_maxsize_hints(window, window.geometry_hints)
 
         if LANGCHANGE:
-            def inputlangchange(_hwnd: int, _event: int, wParam: int, lParam: int) -> int:
+            def inputlangchange(_hwnd: int, _event: int, wParam: int, lParam: int) -> None:
                 keylog("WM_INPUTLANGCHANGE: character set: %i, input locale identifier: %i", wParam, lParam)
                 window.keyboard_layout_changed("WM_INPUTLANGCHANGE", wParam, lParam)
-                return 0
+                # Returning None makes `Win32Hooks._wndproc` forward the message to the
+                # original (GDK) window procedure. GDK-Win32 handles WM_INPUTLANGCHANGE by
+                # switching its active keyboard layout and emitting `keys-changed`;
+                # swallowing the message here left GDK translating key events with the
+                # layout that was active at startup, so after a layout switch the server
+                # received keysyms of the old layout and typing stopped working (#3857).
+                return None
 
             win32hooks.add_window_event_handler(win32con.WM_INPUTLANGCHANGE, inputlangchange)
 


### PR DESCRIPTION
## Symptom

MS Windows GTK client, seamless session, two input languages (`ru` + `us`, switched with Alt+Shift). Typing works only in the layout that was active when the client started. After switching the layout, keys stop producing characters; switching back restores typing. Same symptom as #3857 (which was closed after adding layout polling, but the underlying issue remained).

## Root cause

`add_window_hooks()` installs a `WM_INPUTLANGCHANGE` hook whose callback returns `0`. In `Win32Hooks._wndproc` the original window procedure is only called when the callback returns `None`, so GDK's own wndproc never sees the message.

GDK-Win32 relies on exactly this message to switch layouts (`gdk/win32/gdkevents-win32.c`, `case WM_INPUTLANGCHANGE:` → `_gdk_win32_keymap_set_active_layout(...)`, `_gdk_keymap_serial++`). Without it GDK keeps translating key events with the startup layout.

The result is visible with `-d keyboard` on the client: after Alt+Shift the client detects the change and tells the server about it, but the key events it sends are still from the old layout:

```
keyboard layout 'United States - English' : 'us' (0x409)
keymap has been changed to 'us'
 sending updated mappings to the server
do_send_keyboard('layout-changed', 'us', '', '', '', '')
...
do_send_keyboard('key-action', ..., 'Cyrillic_ie', True, [], 1733, 'е', 84, 0)
do_send_keyboard('key-action', ..., 'Cyrillic_u', True, [], 1749, 'у', 69, 0)
```

The server is now configured for `us`, cannot map `Cyrillic_*` keysyms, and nothing is typed.

## Fix

Return `None` from the hook so `_wndproc` forwards the message to GDK. GDK updates its keymap and emits `keys-changed`; the existing `keymap_changed` handler in the GTK keyboard helper then re-queries the layout and reconfigures the server as before, so the xpra-side notification still happens. The native win32 backend (`window_events.py`) has its own path and is not affected.

## Verification

Client: Windows 11, xpra 6.5.3-r0 GTK client. Server: Ubuntu 24.04, xpra 6.5.3-r0 seamless session, `-d keyboard` on both sides.

- Default settings: after Alt+Shift the server receives `Cyrillic_*` keysyms while the layout is `us`; typing dead until switching back.
- With `XPRA_WIN32_LANGCHANGE=0` (which disables the hook, i.e. the same effect as this change): `t e s t` after the switch, `Cyrillic_*` after switching back, Ctrl+A/C/V work in both layouts, several switches in a row, and starting the client in either layout all behave correctly. The server log shows `layout-changed` being sent on every switch, so the xpra notification path keeps working without the hook.

I have not rebuilt the Windows installer with this patch; the verification above relies on the env var producing the identical code path.

Disclosure: the analysis and this patch were done with AI assistance (Claude) and tested by a human on the setup described above.

Fixes #3857
